### PR TITLE
Migrate to the audited globus-go-sdk v3 API surface

### DIFF
--- a/cmd/compute/endpoint_list.go
+++ b/cmd/compute/endpoint_list.go
@@ -48,9 +48,14 @@ Examples:
 }
 
 func init() {
-	EndpointListCmd.Flags().IntVar(&endpointListLimit, "limit", 25, "Maximum number of endpoints to return")
-	EndpointListCmd.Flags().StringVar(&endpointListSearch, "search", "", "Search endpoints by name")
-	EndpointListCmd.Flags().StringVar(&endpointListStatus, "status", "", "Filter by status")
+	// The Compute endpoints API has no server-side paging or name search, so
+	// these two flags are no-ops kept for backward compatibility. --status is
+	// applied client-side.
+	EndpointListCmd.Flags().IntVar(&endpointListLimit, "limit", 25, "Deprecated: the API does not paginate endpoints")
+	EndpointListCmd.Flags().StringVar(&endpointListSearch, "search", "", "Deprecated: the API has no endpoint name search")
+	EndpointListCmd.Flags().StringVar(&endpointListStatus, "status", "", "Filter by status (applied client-side)")
+	_ = EndpointListCmd.Flags().MarkDeprecated("limit", "the API does not paginate endpoints")
+	_ = EndpointListCmd.Flags().MarkDeprecated("search", "the API has no endpoint name search")
 }
 
 func runEndpointList(cmd *cobra.Command, args []string) error {
@@ -90,22 +95,23 @@ func runEndpointList(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Build list options
-	options := &compute.ListEndpointsOptions{
-		PerPage:     endpointListLimit,
-		IncludeInfo: true,
-	}
-	if endpointListSearch != "" {
-		options.Search = endpointListSearch
-	}
-	if endpointListStatus != "" {
-		options.FilterStatus = endpointListStatus
-	}
-
-	// List endpoints
-	endpointList, err := computeClient.ListEndpoints(ctx, options)
+	// The Compute API returns a top-level array of endpoint documents. It has no
+	// server-side search/status/per-page filters, so those flags are applied
+	// client-side where possible. Only the "role" query param is supported.
+	endpoints, err := computeClient.GetEndpoints(ctx, &compute.GetEndpointsOptions{Role: "owner"})
 	if err != nil {
 		return fmt.Errorf("error listing endpoints: %w", err)
+	}
+
+	// Optional client-side status filter.
+	if endpointListStatus != "" {
+		filtered := endpoints[:0]
+		for _, ep := range endpoints {
+			if mapStr(ep, "status") == endpointListStatus {
+				filtered = append(filtered, ep)
+			}
+		}
+		endpoints = filtered
 	}
 
 	// Format output
@@ -113,7 +119,7 @@ func runEndpointList(cmd *cobra.Command, args []string) error {
 
 	if format == "text" {
 		// Text output - human readable table
-		if len(endpointList.Endpoints) == 0 {
+		if len(endpoints) == 0 {
 			fmt.Println("No endpoints found.")
 			return nil
 		}
@@ -125,38 +131,51 @@ func runEndpointList(cmd *cobra.Command, args []string) error {
 			"----------",
 			"----------")
 
-		for _, endpoint := range endpointList.Endpoints {
-			name := endpoint.Name
+		for _, endpoint := range endpoints {
+			name := mapStr(endpoint, "name")
 			if len(name) > 30 {
 				name = name[:27] + "..."
 			}
 
-			status := endpoint.Status
+			status := mapStr(endpoint, "status")
 			if status == "" {
 				status = "unknown"
 			}
 
 			connected := "No"
-			if endpoint.Connected {
+			if b, ok := endpoint["connected"].(bool); ok && b {
 				connected = "Yes"
 			}
 
+			uuid := mapStr(endpoint, "uuid")
+			if uuid == "" {
+				uuid = mapStr(endpoint, "endpoint_id")
+			}
+
 			fmt.Printf("%-36s  %-30s  %-10s  %-10s\n",
-				endpoint.UUID,
+				uuid,
 				name,
 				status,
 				connected)
 		}
 
-		fmt.Printf("\nTotal: %d endpoint(s)\n", len(endpointList.Endpoints))
+		fmt.Printf("\nTotal: %d endpoint(s)\n", len(endpoints))
 	} else {
-		// JSON or CSV output
+		// JSON or CSV output — emit the raw passthrough documents.
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"UUID", "Name", "Description", "Status", "Connected", "Owner", "CreatedAt"}
-		if err := formatter.FormatOutput(endpointList.Endpoints, headers); err != nil {
+		headers := []string{"uuid", "name", "description", "status", "connected", "owner"}
+		if err := formatter.FormatOutput(endpoints, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}
 	}
 
 	return nil
+}
+
+// mapStr returns the string value at key in m, or "" if absent/not a string.
+func mapStr(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
 }

--- a/cmd/compute/endpoint_show.go
+++ b/cmd/compute/endpoint_show.go
@@ -84,44 +84,37 @@ func runEndpointShow(cmd *cobra.Command, args []string) error {
 	format := viper.GetString("format")
 
 	if format == "text" {
-		// Text output - human readable
+		// Text output - human readable. The endpoint is an open-ended document;
+		// render the well-known fields and fall back to keys where present.
 		fmt.Printf("Endpoint Details\n")
 		fmt.Printf("================\n\n")
 
-		fmt.Printf("Endpoint ID:   %s\n", endpoint.UUID)
-		fmt.Printf("Name:          %s\n", endpoint.Name)
-		if endpoint.Description != "" {
-			fmt.Printf("Description:   %s\n", endpoint.Description)
+		uuid := mapStr(endpoint, "uuid")
+		if uuid == "" {
+			uuid = mapStr(endpoint, "endpoint_id")
 		}
-		fmt.Printf("Status:        %s\n", endpoint.Status)
-		fmt.Printf("Connected:     %t\n", endpoint.Connected)
-		fmt.Printf("Public:        %t\n", endpoint.Public)
-		if endpoint.Type != "" {
-			fmt.Printf("Type:          %s\n", endpoint.Type)
+		fmt.Printf("Endpoint ID:   %s\n", uuid)
+		fmt.Printf("Name:          %s\n", mapStr(endpoint, "name"))
+		if d := mapStr(endpoint, "description"); d != "" {
+			fmt.Printf("Description:   %s\n", d)
 		}
-		fmt.Printf("Owner:         %s\n", endpoint.Owner)
-		if !endpoint.CreatedAt.IsZero() {
-			fmt.Printf("Created:       %s\n", endpoint.CreatedAt.Format(time.RFC3339))
+		fmt.Printf("Status:        %s\n", mapStr(endpoint, "status"))
+		if b, ok := endpoint["connected"].(bool); ok {
+			fmt.Printf("Connected:     %t\n", b)
 		}
-		if !endpoint.LastModified.IsZero() {
-			fmt.Printf("Modified:      %s\n", endpoint.LastModified.Format(time.RFC3339))
+		if b, ok := endpoint["public"].(bool); ok {
+			fmt.Printf("Public:        %t\n", b)
 		}
-
-		// Display metrics if available
-		if endpoint.Metrics != nil {
-			fmt.Printf("\nMetrics:\n")
-			fmt.Printf("  Utilization:     %.2f%%\n", endpoint.Metrics.Utilization*100)
-			if len(endpoint.Metrics.OutstandingCounts) > 0 {
-				fmt.Printf("  Outstanding:     %v\n", endpoint.Metrics.OutstandingCounts)
-			}
-			if len(endpoint.Metrics.RunningCounts) > 0 {
-				fmt.Printf("  Running:         %v\n", endpoint.Metrics.RunningCounts)
-			}
+		if t := mapStr(endpoint, "endpoint_type"); t != "" {
+			fmt.Printf("Type:          %s\n", t)
+		}
+		if o := mapStr(endpoint, "owner"); o != "" {
+			fmt.Printf("Owner:         %s\n", o)
 		}
 	} else {
-		// JSON or CSV output
+		// JSON or CSV output — emit the raw passthrough document.
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"UUID", "Name", "Description", "Status", "Connected", "Public", "Type", "Owner", "CreatedAt", "LastModified"}
+		headers := []string{"uuid", "name", "description", "status", "connected", "public", "endpoint_type", "owner"}
 		if err := formatter.FormatOutput(endpoint, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/compute/function_delete.go
+++ b/cmd/compute/function_delete.go
@@ -99,9 +99,8 @@ func runFunctionDelete(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Delete function
-	err = computeClient.DeleteFunction(ctx, functionID)
-	if err != nil {
+	// Delete function (returns the passthrough result document, ignored here)
+	if _, err = computeClient.DeleteFunction(ctx, functionID); err != nil {
 		return fmt.Errorf("error deleting function: %w", err)
 	}
 

--- a/cmd/compute/function_list.go
+++ b/cmd/compute/function_list.go
@@ -3,22 +3,9 @@
 package compute
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-)
-
-var (
-	functionListLimit int
 )
 
 // FunctionListCmd represents the compute function list command
@@ -27,122 +14,12 @@ var FunctionListCmd = &cobra.Command{
 	Short: "List registered Globus Compute functions",
 	Long: `List functions you have registered with Globus Compute.
 
-Examples:
-  # List all your functions
-  globus compute function list
-
-  # Limit results
-  globus compute function list --limit 50
-
-  # JSON output for scripting
-  globus compute function list --format json`,
+NOTE: The Globus Compute API does not expose a function-listing endpoint, so
+this command is not supported. Retrieve a specific function by ID with
+"globus compute function show FUNCTION_ID".`,
 	RunE: runFunctionList,
 }
 
-func init() {
-	FunctionListCmd.Flags().IntVar(&functionListLimit, "limit", 25, "Maximum number of functions to return")
-}
-
 func runFunctionList(cmd *cobra.Command, args []string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
-	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Build list options
-	options := &compute.ListFunctionsOptions{
-		PerPage: functionListLimit,
-	}
-
-	// List functions
-	functionList, err := computeClient.ListFunctions(ctx, options)
-	if err != nil {
-		return fmt.Errorf("error listing functions: %w", err)
-	}
-
-	// Format output
-	format := viper.GetString("format")
-
-	if format == "text" {
-		// Text output - human readable table
-		if len(functionList.Functions) == 0 {
-			fmt.Println("No functions found.")
-			return nil
-		}
-
-		fmt.Printf("%-36s  %-30s  %-10s  %-10s\n", "Function ID", "Name", "Status", "Public")
-		fmt.Printf("%s  %s  %s  %s\n",
-			"------------------------------------",
-			"------------------------------",
-			"----------",
-			"----------")
-
-		for _, function := range functionList.Functions {
-			name := function.Name
-			if name == "" {
-				name = "(unnamed)"
-			}
-			if len(name) > 30 {
-				name = name[:27] + "..."
-			}
-
-			status := function.Status
-			if status == "" {
-				status = "active"
-			}
-
-			public := "No"
-			if function.Public {
-				public = "Yes"
-			}
-
-			fmt.Printf("%-36s  %-30s  %-10s  %-10s\n",
-				function.ID,
-				name,
-				status,
-				public)
-		}
-
-		fmt.Printf("\nTotal: %d function(s)\n", len(functionList.Functions))
-	} else {
-		// JSON or CSV output
-		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"ID", "Name", "Description", "Status", "Public", "Owner", "CreatedAt"}
-		if err := formatter.FormatOutput(functionList.Functions, headers); err != nil {
-			return fmt.Errorf("error formatting output: %w", err)
-		}
-	}
-
-	return nil
+	return fmt.Errorf("listing functions is not supported by the Globus Compute API; use \"globus compute function show FUNCTION_ID\"")
 }

--- a/cmd/compute/function_register.go
+++ b/cmd/compute/function_register.go
@@ -110,28 +110,27 @@ func runFunctionRegister(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Build register request
-	request := &compute.FunctionRegisterRequest{
-		Function:    functionCode,
-		Name:        registerName,
-		Description: registerDescription,
-		Public:      registerPublic,
-	}
-
-	// Register function
-	function, err := computeClient.RegisterFunction(ctx, request)
+	// Register function. The Compute API takes and returns open-ended documents.
+	function, err := computeClient.RegisterFunction(ctx, map[string]interface{}{
+		"function_name": registerName,
+		"function_code": functionCode,
+		"description":   registerDescription,
+		"public":        registerPublic,
+	})
 	if err != nil {
 		return fmt.Errorf("error registering function: %w", err)
 	}
 
-	// Display success message
-	fmt.Fprintf(os.Stdout, "Function registered successfully!\n\n")
-	fmt.Fprintf(os.Stdout, "Function ID:   %s\n", function.ID)
-	if function.Name != "" {
-		fmt.Fprintf(os.Stdout, "Name:          %s\n", function.Name)
+	// Display success message. The registered id is keyed under function_uuid.
+	functionID := mapStr(function, "function_uuid")
+	if functionID == "" {
+		functionID = mapStr(function, "function_id")
 	}
-	fmt.Fprintf(os.Stdout, "Public:        %t\n", function.Public)
-	fmt.Fprintf(os.Stdout, "Created:       %s\n", function.CreatedAt.Format(time.RFC3339))
+	fmt.Fprintf(os.Stdout, "Function registered successfully!\n\n")
+	fmt.Fprintf(os.Stdout, "Function ID:   %s\n", functionID)
+	if n := mapStr(function, "function_name"); n != "" {
+		fmt.Fprintf(os.Stdout, "Name:          %s\n", n)
+	}
 
 	return nil
 }

--- a/cmd/compute/function_show.go
+++ b/cmd/compute/function_show.go
@@ -84,56 +84,38 @@ func runFunctionShow(cmd *cobra.Command, args []string) error {
 	format := viper.GetString("format")
 
 	if format == "text" {
-		// Text output - human readable
+		// Text output - human readable. The function is an open-ended document.
 		fmt.Printf("Function Details\n")
 		fmt.Printf("================\n\n")
 
-		fmt.Printf("Function ID:   %s\n", function.ID)
-		if function.Name != "" {
-			fmt.Printf("Name:          %s\n", function.Name)
+		id := mapStr(function, "function_uuid")
+		if id == "" {
+			id = mapStr(function, "function_id")
 		}
-		if function.Description != "" {
-			fmt.Printf("Description:   %s\n", function.Description)
+		fmt.Printf("Function ID:   %s\n", id)
+		if n := mapStr(function, "function_name"); n != "" {
+			fmt.Printf("Name:          %s\n", n)
 		}
-		fmt.Printf("Status:        %s\n", function.Status)
-		fmt.Printf("Public:        %t\n", function.Public)
-		fmt.Printf("Owner:         %s\n", function.Owner)
-		if !function.CreatedAt.IsZero() {
-			fmt.Printf("Created:       %s\n", function.CreatedAt.Format(time.RFC3339))
+		if d := mapStr(function, "description"); d != "" {
+			fmt.Printf("Description:   %s\n", d)
 		}
-		if !function.ModifiedAt.IsZero() {
-			fmt.Printf("Modified:      %s\n", function.ModifiedAt.Format(time.RFC3339))
+		if b, ok := function["public"].(bool); ok {
+			fmt.Printf("Public:        %t\n", b)
 		}
 
-		// Display function code (truncated if very long)
-		if function.Function != "" {
+		// Display function code (truncated if very long) if present.
+		if code := mapStr(function, "function_code"); code != "" {
 			fmt.Printf("\nFunction Code:\n")
-			code := function.Function
 			if len(code) > 500 {
 				fmt.Printf("%s\n... (truncated, %d total characters)\n", code[:500], len(code))
 			} else {
 				fmt.Printf("%s\n", code)
 			}
 		}
-
-		// Display environment variables
-		if len(function.Environment) > 0 {
-			fmt.Printf("\nEnvironment Variables:\n")
-			for key, value := range function.Environment {
-				fmt.Printf("  %s: %s\n", key, value)
-			}
-		}
-
-		// Display container info
-		if function.Container != nil {
-			fmt.Printf("\nContainer:\n")
-			fmt.Printf("  Image:  %s\n", function.Container.Image)
-			fmt.Printf("  Type:   %s\n", function.Container.Type)
-		}
 	} else {
-		// JSON or CSV output
+		// JSON or CSV output — emit the raw passthrough document.
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"ID", "Name", "Description", "Status", "Public", "Owner", "CreatedAt", "ModifiedAt"}
+		headers := []string{"function_uuid", "function_name", "description", "public"}
 		if err := formatter.FormatOutput(function, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/compute/function_update.go
+++ b/cmd/compute/function_update.go
@@ -3,17 +3,9 @@
 package compute
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -28,18 +20,9 @@ var FunctionUpdateCmd = &cobra.Command{
 	Short: "Update a registered function's metadata",
 	Long: `Update a function's name, description, or visibility.
 
-Note: You cannot update the function code itself. To change code,
-register a new function version.
-
-Examples:
-  # Update function name
-  globus compute function update FUNCTION_ID --name "new_name"
-
-  # Update description
-  globus compute function update FUNCTION_ID --description "Updated description"
-
-  # Make function public
-  globus compute function update FUNCTION_ID --public=true`,
+NOTE: The Globus Compute API does not expose a function-update endpoint, so
+this command is not supported. Register a new function instead with
+"globus compute function register".`,
 	Args: cobra.ExactArgs(1),
 	RunE: runFunctionUpdate,
 }
@@ -55,77 +38,5 @@ func init() {
 }
 
 func runFunctionUpdate(cmd *cobra.Command, args []string) error {
-	functionID := args[0]
-
-	// Build update request with only specified fields
-	request := &compute.FunctionUpdateRequest{}
-
-	if updateName != "" {
-		request.Name = updateName
-	}
-
-	if updateDescription != "" {
-		request.Description = updateDescription
-	}
-
-	if cmd.Flags().Changed("public") {
-		request.Public = updatePublic
-	}
-
-	// Validate that at least one field is being updated
-	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") && !cmd.Flags().Changed("public") {
-		return fmt.Errorf("at least one of --name, --description, or --public must be specified")
-	}
-
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
-	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Update function
-	function, err := computeClient.UpdateFunction(ctx, functionID, request)
-	if err != nil {
-		return fmt.Errorf("error updating function: %w", err)
-	}
-
-	// Display success message
-	fmt.Fprintf(os.Stdout, "Function updated successfully!\n\n")
-	fmt.Fprintf(os.Stdout, "Function ID:   %s\n", function.ID)
-	if function.Name != "" {
-		fmt.Fprintf(os.Stdout, "Name:          %s\n", function.Name)
-	}
-	fmt.Fprintf(os.Stdout, "Modified:      %s\n", function.ModifiedAt.Format(time.RFC3339))
-
-	return nil
+	return fmt.Errorf("updating functions is not supported by the Globus Compute API; register a new function instead")
 }

--- a/cmd/compute/task_cancel.go
+++ b/cmd/compute/task_cancel.go
@@ -3,17 +3,9 @@
 package compute
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // TaskCancelCmd represents the compute task cancel command
@@ -22,63 +14,13 @@ var TaskCancelCmd = &cobra.Command{
 	Short: "Cancel a running task",
 	Long: `Cancel a task that is currently executing or pending.
 
-This attempts to gracefully cancel the task execution. The task may
-still complete if cancellation occurs after execution has finished.
-
-Examples:
-  # Cancel a task
-  globus compute task cancel TASK_ID`,
+NOTE: The Globus Compute API does not expose a task-cancellation endpoint,
+so this command is not supported. Tasks are managed through the executing
+Compute endpoint, not the web service.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runTaskCancel,
 }
 
 func runTaskCancel(cmd *cobra.Command, args []string) error {
-	taskID := args[0]
-
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
-	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Cancel task
-	err = computeClient.CancelTask(ctx, taskID)
-	if err != nil {
-		return fmt.Errorf("error canceling task: %w", err)
-	}
-
-	fmt.Fprintf(os.Stdout, "Task %s canceled successfully.\n", taskID)
-	fmt.Fprintf(os.Stdout, "\nCheck status with: globus compute task show %s\n", taskID)
-
-	return nil
+	return fmt.Errorf("task cancellation is not supported by the Globus Compute API")
 }

--- a/cmd/compute/task_list.go
+++ b/cmd/compute/task_list.go
@@ -3,21 +3,9 @@
 package compute
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-)
-
-var (
-	taskListLimit int
 )
 
 // TaskListCmd represents the compute task list command
@@ -26,101 +14,12 @@ var TaskListCmd = &cobra.Command{
 	Short: "List tasks",
 	Long: `List recent task executions.
 
-Examples:
-  # List recent tasks
-  globus compute task list
-
-  # Limit results
-  globus compute task list --limit 50
-
-  # JSON output for scripting
-  globus compute task list --format json`,
+NOTE: The Globus Compute API does not expose a task-listing endpoint, so this
+command is not supported. Query individual tasks by ID with
+"globus compute task show TASK_ID", or a batch with the task-group ID.`,
 	RunE: runTaskList,
 }
 
-func init() {
-	TaskListCmd.Flags().IntVar(&taskListLimit, "limit", 25, "Maximum number of tasks to return")
-}
-
 func runTaskList(cmd *cobra.Command, args []string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
-	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Build list options
-	options := &compute.TaskListOptions{
-		PerPage: taskListLimit,
-	}
-
-	// List tasks
-	taskList, err := computeClient.ListTasks(ctx, options)
-	if err != nil {
-		return fmt.Errorf("error listing tasks: %w", err)
-	}
-
-	// Format output
-	format := viper.GetString("format")
-
-	if format == "text" {
-		// Text output - human readable table
-		if len(taskList.Tasks) == 0 {
-			fmt.Println("No tasks found.")
-			return nil
-		}
-
-		fmt.Printf("Task IDs:\n")
-		fmt.Printf("=========\n\n")
-
-		for i, taskID := range taskList.Tasks {
-			fmt.Printf("%d. %s\n", i+1, taskID)
-		}
-
-		fmt.Printf("\nTotal: %d task(s)\n", taskList.Total)
-	} else {
-		// JSON output - output task list structure
-		if format == "json" {
-			output, _ := json.MarshalIndent(taskList, "", "  ")
-			fmt.Println(string(output))
-		} else {
-			// CSV output - just the task IDs
-			fmt.Println("TaskID")
-			for _, taskID := range taskList.Tasks {
-				fmt.Println(taskID)
-			}
-		}
-	}
-
-	return nil
+	return fmt.Errorf("listing tasks is not supported by the Globus Compute API; use \"globus compute task show TASK_ID\"")
 }

--- a/cmd/compute/task_run.go
+++ b/cmd/compute/task_run.go
@@ -3,18 +3,9 @@
 package compute
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"os"
-	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -28,21 +19,11 @@ var TaskRunCmd = &cobra.Command{
 	Short: "Execute a function on an endpoint",
 	Long: `Execute a registered function on a specified compute endpoint.
 
-You can provide function arguments as JSON input either from a file or inline.
-The input should be a JSON object with "args" (array) and/or "kwargs" (object).
-
-Examples:
-  # Run a function with no arguments
-  globus compute task run FUNCTION_ID ENDPOINT_ID
-
-  # Run with positional arguments
-  globus compute task run FUNCTION_ID ENDPOINT_ID --input '{"args": [1, 2, 3]}'
-
-  # Run with keyword arguments
-  globus compute task run FUNCTION_ID ENDPOINT_ID --input '{"kwargs": {"x": 10, "y": 20}}'
-
-  # Run with input from file
-  globus compute task run FUNCTION_ID ENDPOINT_ID --file input.json`,
+NOTE: The Globus Compute submit API requires arguments serialized with the
+Globus Compute (dill/base64) format, which this CLI cannot produce. Use the
+Globus Compute Python SDK/Executor to run functions. The web-service submit
+endpoint is available in the Go SDK as compute.Client.Submit for callers that
+build the serialized payload themselves.`,
 	Args: cobra.ExactArgs(2),
 	RunE: runTaskRun,
 }
@@ -53,97 +34,5 @@ func init() {
 }
 
 func runTaskRun(cmd *cobra.Command, args []string) error {
-	functionID := args[0]
-	endpointID := args[1]
-
-	// Parse input if provided
-	var taskArgs []interface{}
-	var taskKwargs map[string]interface{}
-
-	if taskRunFile != "" || taskRunInput != "" {
-		if taskRunFile != "" && taskRunInput != "" {
-			return fmt.Errorf("cannot specify both --file and --input")
-		}
-
-		var inputJSON []byte
-		var err error
-
-		if taskRunFile != "" {
-			inputJSON, err = os.ReadFile(taskRunFile)
-			if err != nil {
-				return fmt.Errorf("failed to read input file: %w", err)
-			}
-		} else {
-			inputJSON = []byte(taskRunInput)
-		}
-
-		// Parse input JSON
-		var input struct {
-			Args   []interface{}          `json:"args"`
-			Kwargs map[string]interface{} `json:"kwargs"`
-		}
-		if err := json.Unmarshal(inputJSON, &input); err != nil {
-			return fmt.Errorf("failed to parse input JSON: %w", err)
-		}
-
-		taskArgs = input.Args
-		taskKwargs = input.Kwargs
-	}
-
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
-	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Build task request
-	request := &compute.TaskRequest{
-		FunctionID: functionID,
-		EndpointID: endpointID,
-		Args:       taskArgs,
-		Kwargs:     taskKwargs,
-	}
-
-	// Run the function
-	response, err := computeClient.RunFunction(ctx, request)
-	if err != nil {
-		return fmt.Errorf("error running function: %w", err)
-	}
-
-	// Display task information
-	fmt.Fprintf(os.Stdout, "Function execution started successfully!\n\n")
-	fmt.Fprintf(os.Stdout, "Task ID:    %s\n", response.TaskID)
-	fmt.Fprintf(os.Stdout, "\nMonitor task status with: globus compute task show %s\n", response.TaskID)
-
-	return nil
+	return fmt.Errorf("running functions from the CLI is not supported: the Compute submit API requires Globus Compute-serialized arguments; use the Globus Compute Python SDK")
 }

--- a/cmd/compute/task_show.go
+++ b/cmd/compute/task_show.go
@@ -76,8 +76,8 @@ func runTaskShow(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Get task status
-	taskStatus, err := computeClient.GetTaskStatus(ctx, taskID)
+	// Get task status (GET /v2/tasks/{id}); the response is an open-ended document.
+	taskStatus, err := computeClient.GetTask(ctx, taskID)
 	if err != nil {
 		return fmt.Errorf("error getting task status: %w", err)
 	}
@@ -90,28 +90,28 @@ func runTaskShow(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Task Details\n")
 		fmt.Printf("============\n\n")
 
-		fmt.Printf("Task ID:       %s\n", taskStatus.TaskID)
-		fmt.Printf("Status:        %s\n", taskStatus.Status)
-
-		if !taskStatus.CompletedAt.IsZero() {
-			fmt.Printf("Completed:     %s\n", taskStatus.CompletedAt.Format(time.RFC3339))
+		id := mapStr(taskStatus, "task_id")
+		if id == "" {
+			id = taskID
 		}
+		fmt.Printf("Task ID:       %s\n", id)
+		fmt.Printf("Status:        %s\n", mapStr(taskStatus, "status"))
 
 		// Display result if available
-		if taskStatus.Result != nil {
+		if result, ok := taskStatus["result"]; ok && result != nil {
 			fmt.Printf("\nResult:\n")
-			resultJSON, _ := json.MarshalIndent(taskStatus.Result, "  ", "  ")
+			resultJSON, _ := json.MarshalIndent(result, "  ", "  ")
 			fmt.Printf("%s\n", string(resultJSON))
 		}
 
 		// Display exception if task failed
-		if taskStatus.Exception != "" {
-			fmt.Printf("\nException:\n%s\n", taskStatus.Exception)
+		if ex := mapStr(taskStatus, "exception"); ex != "" {
+			fmt.Printf("\nException:\n%s\n", ex)
 		}
 	} else {
-		// JSON or CSV output
+		// JSON or CSV output — emit the raw passthrough document.
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"TaskID", "Status", "CompletedAt"}
+		headers := []string{"task_id", "status", "completion_t"}
 		if err := formatter.FormatOutput(taskStatus, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/flows/run_show_logs.go
+++ b/cmd/flows/run_show_logs.go
@@ -110,7 +110,7 @@ func runFlowsRunShowLogs(cmd *cobra.Command, args []string) error {
 
 		for i, entry := range logs.Entries {
 			fmt.Printf("Entry %d:\n", i+1)
-			fmt.Printf("  Time:    %s\n", entry.CreatedAt.Format(time.RFC3339))
+			fmt.Printf("  Time:    %s\n", entry.Time.Format(time.RFC3339))
 			fmt.Printf("  Code:    %s\n", entry.Code)
 			if entry.Description != "" {
 				fmt.Printf("  Desc:    %s\n", entry.Description)

--- a/cmd/flows/start.go
+++ b/cmd/flows/start.go
@@ -136,7 +136,7 @@ func runFlowsStart(cmd *cobra.Command, args []string) error {
 	// Build run request
 	request := &flows.RunRequest{
 		FlowID: flowID,
-		Input:  input,
+		Body:   input,
 		Label:  startLabel,
 		Tags:   startTags,
 	}

--- a/cmd/group/list.go
+++ b/cmd/group/list.go
@@ -46,7 +46,10 @@ Output Formats:
 }
 
 func init() {
-	ListCmd.Flags().BoolVar(&listMyGroupsOnly, "my-groups", false, "List only groups where you are a member")
+	// The Groups API only returns the caller's own groups, so this flag is a
+	// no-op kept for backward compatibility.
+	ListCmd.Flags().BoolVar(&listMyGroupsOnly, "my-groups", false, "Deprecated: the API always lists only your groups")
+	_ = ListCmd.Flags().MarkDeprecated("my-groups", "the API only lists your groups")
 	ListCmd.Flags().StringArrayVar(&listIncludeStatuses, "include-status", []string{}, "Include groups with specific statuses (active, pending, etc.)")
 }
 
@@ -89,18 +92,9 @@ func runListGroups(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Prepare options for listing groups
-	options := &groups.ListGroupsOptions{
-		MyGroups: listMyGroupsOnly,
-	}
-
-	// SDK v3.65.0-1 supports status filtering via Statuses field
-	if len(listIncludeStatuses) > 0 {
-		options.Statuses = listIncludeStatuses
-	}
-
-	// List groups
-	groupList, err := groupsClient.ListGroups(ctx, options)
+	// The Globus Groups API only lists the caller's own groups
+	// (GET /groups/my_groups); optional status filtering is passed through.
+	groupList, err := groupsClient.GetMyGroups(ctx, listIncludeStatuses)
 	if err != nil {
 		return fmt.Errorf("error listing groups: %w", err)
 	}

--- a/cmd/group/member_add.go
+++ b/cmd/group/member_add.go
@@ -86,8 +86,11 @@ func runMemberAdd(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Add member to group
-	err = groupsClient.AddMember(ctx, groupID, identityID, memberAddRole)
+	// Add member to group via a single batch membership action
+	// (POST /groups/{id}); the API has no dedicated add-member route.
+	_, err = groupsClient.BatchMembershipAction(ctx, groupID, &groups.BatchMembershipActions{
+		Add: []groups.MemberWithRole{{IdentityID: identityID, Role: memberAddRole}},
+	})
 	if err != nil {
 		return fmt.Errorf("error adding member: %w", err)
 	}

--- a/cmd/group/member_list.go
+++ b/cmd/group/member_list.go
@@ -77,18 +77,22 @@ func runMemberList(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// List members
-	memberList, err := groupsClient.ListMembers(ctx, groupID, nil)
+	// Members are returned by fetching the group with the memberships
+	// representation (the API has no standalone list-members route).
+	group, err := groupsClient.GetGroup(ctx, groupID, &groups.GetGroupOptions{
+		Include: []string{"memberships"},
+	})
 	if err != nil {
 		return fmt.Errorf("error listing members: %w", err)
 	}
+	members := group.Memberships
 
 	// Format output
 	format := viper.GetString("format")
 
 	if format == "text" {
 		// Text output - human readable table
-		if len(memberList.Members) == 0 {
+		if len(members) == 0 {
 			fmt.Println("No members found.")
 			return nil
 		}
@@ -100,13 +104,13 @@ func runMemberList(cmd *cobra.Command, args []string) error {
 			"--------------------",
 			"----------")
 
-		for _, member := range memberList.Members {
+		for _, member := range members {
 			username := member.Username
 			if username == "" {
 				username = "(unknown)"
 			}
 
-			role := member.RoleID
+			role := member.Role
 			if role == "" {
 				role = "member"
 			}
@@ -123,12 +127,12 @@ func runMemberList(cmd *cobra.Command, args []string) error {
 				status)
 		}
 
-		fmt.Printf("\nTotal: %d member(s)\n", len(memberList.Members))
+		fmt.Printf("\nTotal: %d member(s)\n", len(members))
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"IdentityID", "Username", "RoleID", "Status"}
-		if err := formatter.FormatOutput(memberList.Members, headers); err != nil {
+		headers := []string{"IdentityID", "Username", "Role", "Status"}
+		if err := formatter.FormatOutput(members, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}
 	}

--- a/cmd/group/member_remove.go
+++ b/cmd/group/member_remove.go
@@ -71,8 +71,11 @@ func runMemberRemove(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Remove member from group
-	err = groupsClient.RemoveMember(ctx, groupID, identityID)
+	// Remove member from group via a single batch membership action
+	// (POST /groups/{id}); the API has no dedicated remove-member route.
+	_, err = groupsClient.BatchMembershipAction(ctx, groupID, &groups.BatchMembershipActions{
+		Remove: []groups.MemberID{{IdentityID: identityID}},
+	})
 	if err != nil {
 		return fmt.Errorf("error removing member: %w", err)
 	}

--- a/cmd/group/show.go
+++ b/cmd/group/show.go
@@ -80,8 +80,9 @@ func runShowGroup(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Get group details
-	group, err := groupsClient.GetGroup(ctx, groupID)
+	// Get group details (include memberships/policies via GetGroupOptions;
+	// nil requests the default representation).
+	group, err := groupsClient.GetGroup(ctx, groupID, nil)
 	if err != nil {
 		return fmt.Errorf("error getting group: %w", err)
 	}

--- a/cmd/search/index_list.go
+++ b/cmd/search/index_list.go
@@ -136,11 +136,6 @@ func runIndexList(cmd *cobra.Command, args []string) error {
 		}
 
 		fmt.Printf("\nTotal: %d index(es)\n", len(indexList.Indexes))
-
-		if indexList.HasMore {
-			nextOffset := indexListOffset + indexListLimit
-			fmt.Printf("More indices available. Use --offset %d to see next page.\n", nextOffset)
-		}
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)

--- a/cmd/search/subject_delete.go
+++ b/cmd/search/subject_delete.go
@@ -87,14 +87,13 @@ func runSubjectDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error deleting subject: %w", err)
 	}
 
-	// Display success message
+	// Display success message. The delete response carries the top-level task_id.
 	fmt.Fprintf(os.Stdout, "Subject deletion task submitted!\n\n")
-	fmt.Fprintf(os.Stdout, "Task ID:    %s\n", response.Task.TaskID)
+	fmt.Fprintf(os.Stdout, "Task ID:    %s\n", response.TaskID)
 	fmt.Fprintf(os.Stdout, "Subject:    %s\n", subject)
-	fmt.Fprintf(os.Stdout, "Status:     %s\n", response.Task.ProcessingState)
 
-	if response.Task.TaskID != "" {
-		fmt.Fprintf(os.Stdout, "\nCheck task status with: globus search task show %s\n", response.Task.TaskID)
+	if response.TaskID != "" {
+		fmt.Fprintf(os.Stdout, "\nCheck task status with: globus search task show %s\n", response.TaskID)
 	}
 
 	return nil

--- a/cmd/search/task_show.go
+++ b/cmd/search/task_show.go
@@ -89,25 +89,16 @@ func runTaskShow(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Task Information\n")
 		fmt.Printf("================\n\n")
 		fmt.Printf("Task ID:    %s\n", taskStatus.TaskID)
+		fmt.Printf("Index ID:   %s\n", taskStatus.IndexID)
 		fmt.Printf("State:      %s\n", taskStatus.State)
-		fmt.Printf("Created At: %s\n", taskStatus.CreatedAt)
+		if taskStatus.CreatedAt != "" {
+			fmt.Printf("Created At: %s\n", taskStatus.CreatedAt)
+		}
 		if taskStatus.CompletedAt != "" {
 			fmt.Printf("Completed:  %s\n", taskStatus.CompletedAt)
 		}
-
-		fmt.Printf("\nDocument Status\n")
-		fmt.Printf("---------------\n")
-		fmt.Printf("Total:      %d documents\n", taskStatus.TotalDocuments)
-		fmt.Printf("Succeeded:  %d documents\n", taskStatus.SuccessDocuments)
-		fmt.Printf("Failed:     %d documents\n", taskStatus.FailedDocuments)
-		fmt.Printf("Errors:     %d\n", taskStatus.ErrorCount)
-
-		// Show failed subjects if any
-		if len(taskStatus.FailedSubjects) > 0 {
-			fmt.Printf("\nFailed Subjects:\n")
-			for _, subject := range taskStatus.FailedSubjects {
-				fmt.Printf("  - %s\n", subject)
-			}
+		if taskStatus.Message != "" {
+			fmt.Printf("Message:    %s\n", taskStatus.Message)
 		}
 
 		if taskStatus.DetailLocation != "" {
@@ -116,7 +107,7 @@ func runTaskShow(cmd *cobra.Command, args []string) error {
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"TaskID", "State", "TotalDocuments", "SuccessDocuments", "FailedDocuments", "ErrorCount"}
+		headers := []string{"TaskID", "IndexID", "State", "CreatedAt", "CompletedAt", "Message"}
 		if err := formatter.FormatOutput(taskStatus, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/timer/create_flow.go
+++ b/cmd/timer/create_flow.go
@@ -78,14 +78,14 @@ Examples:
 
 func init() {
 	CreateFlowCmd.Flags().StringVar(&createFlowName, "name", "", "Name for the timer (required)")
-	CreateFlowCmd.Flags().StringVar(&createFlowInterval, "interval", "", "ISO 8601 interval for recurring execution (e.g., P1D, P1W, PT1H)")
-	CreateFlowCmd.Flags().StringVar(&createFlowCron, "cron", "", "Cron expression for scheduled execution")
+	CreateFlowCmd.Flags().StringVar(&createFlowInterval, "interval", "", "Interval for recurring execution as a Go duration (e.g., 1h, 30m, 24h)")
+	CreateFlowCmd.Flags().StringVar(&createFlowCron, "cron", "", "Deprecated: cron scheduling is not supported by the Timers API")
 	CreateFlowCmd.Flags().StringVar(&createFlowInput, "input", "{}", "Flow input parameters as JSON string")
 	CreateFlowCmd.Flags().StringVar(&createFlowScope, "flow-scope", "", "Flow scope (required for flow execution)")
 	CreateFlowCmd.Flags().StringVar(&createFlowLabel, "flow-label", "", "Label for the flow run")
 	CreateFlowCmd.Flags().StringVar(&createFlowStart, "start", "", "Start time (RFC3339 format, required)")
 	CreateFlowCmd.Flags().StringVar(&createFlowStop, "stop", "", "Stop time (RFC3339 format)")
-	CreateFlowCmd.Flags().StringVar(&createFlowTimezone, "timezone", "UTC", "Timezone for cron schedule (default: UTC)")
+	CreateFlowCmd.Flags().StringVar(&createFlowTimezone, "timezone", "UTC", "Deprecated: only used with the removed cron scheduling")
 
 	CreateFlowCmd.MarkFlagRequired("name")
 	CreateFlowCmd.MarkFlagRequired("start")
@@ -165,81 +165,57 @@ func runCreateFlowTimer(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Create FlowTimer configuration
-	flowTimer := &timers.FlowTimer{
-		FlowID:    flowID,
-		FlowScope: createFlowScope,
-		FlowInput: flowInput,
-		FlowLabel: createFlowLabel,
+	// Cron scheduling does not exist in the Globus Timers API at this SDK
+	// version; only once and recurring (fixed interval) schedules are supported.
+	if createFlowCron != "" {
+		return fmt.Errorf("cron scheduling is not supported by the Globus Timers API; use --interval for recurring timers")
 	}
 
-	// Additional user data (empty for now)
-	userData := make(map[string]interface{})
-
-	// Create the timer using appropriate FlowTimer helper
-	var createdTimer *timers.Timer
-	var scheduleType string
-
-	if createFlowCron != "" {
-		// Cron-based scheduling (v3.65.0 feature)
-		scheduleType = "cron"
-		createdTimer, err = timersClient.CreateFlowTimerCron(
-			ctx,
-			createFlowName,
-			createFlowCron,
-			createFlowTimezone,
-			stopTime,
-			flowTimer,
-			userData,
-		)
-		if err != nil {
-			return fmt.Errorf("error creating cron flow timer: %w", err)
+	// Build the schedule (once, or recurring by fixed interval).
+	var schedule *timers.Schedule
+	scheduleType := "once"
+	if createFlowInterval != "" {
+		d, derr := time.ParseDuration(createFlowInterval)
+		if derr != nil || d <= 0 {
+			return fmt.Errorf("invalid --interval %q: use a Go duration such as 1h, 30m, or 24h", createFlowInterval)
 		}
-	} else if createFlowInterval != "" {
-		// Recurring scheduling (v3.65.0 feature)
+		var end *timers.ScheduleEnd
+		if stopTime != nil {
+			end = &timers.ScheduleEnd{Condition: "time", Datetime: stopTime.Format(time.RFC3339)}
+		}
+		schedule = timers.NewRecurringSchedule(int(d.Seconds()), startTime.Format(time.RFC3339), end)
 		scheduleType = "recurring"
-		createdTimer, err = timersClient.CreateFlowTimerRecurring(
-			ctx,
-			createFlowName,
-			startTime,
-			createFlowInterval,
-			stopTime,
-			flowTimer,
-			userData,
-		)
-		if err != nil {
-			return fmt.Errorf("error creating recurring flow timer: %w", err)
-		}
 	} else {
-		// One-time execution (v3.65.0 feature)
-		scheduleType = "once"
-		createdTimer, err = timersClient.CreateFlowTimerOnce(
-			ctx,
-			createFlowName,
-			startTime,
-			flowTimer,
-			userData,
-		)
-		if err != nil {
-			return fmt.Errorf("error creating one-time flow timer: %w", err)
-		}
+		schedule = timers.NewOnceSchedule(startTime.Format(time.RFC3339))
+	}
+
+	// Build the flow timer document. Flow input is carried in the body; scope
+	// and label are supplied through the body when the flow requires them.
+	body := map[string]interface{}{"body": flowInput}
+	if createFlowLabel != "" {
+		body["label"] = createFlowLabel
+	}
+	if createFlowScope != "" {
+		body["scope"] = createFlowScope
+	}
+	flowTimer := timers.NewFlowTimer(createFlowName, flowID, schedule, body)
+
+	createdTimer, err := timersClient.CreateTimer(ctx, flowTimer)
+	if err != nil {
+		return fmt.Errorf("error creating flow timer: %w", err)
 	}
 
 	// Display success message
 	fmt.Fprintf(os.Stdout, "Flow timer created successfully!\n\n")
-	fmt.Fprintf(os.Stdout, "Timer ID:    %s\n", createdTimer.ID)
+	fmt.Fprintf(os.Stdout, "Timer ID:    %s\n", createdTimer.JobID)
 	fmt.Fprintf(os.Stdout, "Name:        %s\n", createdTimer.Name)
 	fmt.Fprintf(os.Stdout, "Flow ID:     %s\n", flowID)
 	fmt.Fprintf(os.Stdout, "Schedule:    %s\n", scheduleType)
 	if createFlowInterval != "" {
 		fmt.Fprintf(os.Stdout, "Interval:    %s\n", createFlowInterval)
 	}
-	if createFlowCron != "" {
-		fmt.Fprintf(os.Stdout, "Cron:        %s\n", createFlowCron)
-		fmt.Fprintf(os.Stdout, "Timezone:    %s\n", createFlowTimezone)
-	}
-	if createdTimer.NextDue != nil {
-		fmt.Fprintf(os.Stdout, "Next Run:    %s\n", createdTimer.NextDue.Format(time.RFC3339))
+	if !createdTimer.NextRun.IsZero() {
+		fmt.Fprintf(os.Stdout, "Next Run:    %s\n", createdTimer.NextRun.Format(time.RFC3339))
 	}
 
 	return nil

--- a/cmd/timer/list.go
+++ b/cmd/timer/list.go
@@ -105,10 +105,10 @@ func runListTimers(cmd *cobra.Command, args []string) error {
 				name = name[:27] + "..."
 			}
 
-			// Determine timer type from callback
+			// Timer type is derived from the schedule (once/recurring).
 			timerType := "unknown"
-			if timer.Callback != nil {
-				timerType = timer.Callback.Type
+			if timer.Schedule != nil && timer.Schedule.Type != "" {
+				timerType = timer.Schedule.Type
 			}
 
 			status := "active"
@@ -117,7 +117,7 @@ func runListTimers(cmd *cobra.Command, args []string) error {
 			}
 
 			fmt.Printf("%-36s  %-30s  %-20s  %-10s\n",
-				timer.ID,
+				timer.JobID,
 				name,
 				timerType,
 				status)
@@ -127,7 +127,7 @@ func runListTimers(cmd *cobra.Command, args []string) error {
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"ID", "Name", "CallbackType", "Status"}
+		headers := []string{"JobID", "Name", "Status", "Schedule"}
 		if err := formatter.FormatOutput(timerList.Timers, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/timer/pause.go
+++ b/cmd/timer/pause.go
@@ -80,17 +80,15 @@ func runPauseTimer(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error getting timer: %w", err)
 	}
 
-	// Pause the timer
-	updatedTimer, err := timersClient.PauseTimer(ctx, timerID)
-	if err != nil {
+	// Pause the timer (returns no body; success is signaled by a nil error).
+	if err := timersClient.PauseTimer(ctx, timerID); err != nil {
 		return fmt.Errorf("error pausing timer: %w", err)
 	}
 
 	// Display success message
 	fmt.Fprintf(os.Stdout, "Timer paused successfully!\n\n")
-	fmt.Fprintf(os.Stdout, "Timer ID:    %s\n", updatedTimer.ID)
+	fmt.Fprintf(os.Stdout, "Timer ID:    %s\n", timerID)
 	fmt.Fprintf(os.Stdout, "Name:        %s\n", timer.Name)
-	fmt.Fprintf(os.Stdout, "Status:      %s\n", updatedTimer.Status)
 
 	return nil
 }

--- a/cmd/timer/resume.go
+++ b/cmd/timer/resume.go
@@ -79,20 +79,16 @@ func runResumeTimer(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error getting timer: %w", err)
 	}
 
-	// Resume the timer
-	updatedTimer, err := timersClient.ResumeTimer(ctx, timerID)
-	if err != nil {
+	// Resume the timer. The optional *bool controls whether stored credentials
+	// are refreshed on resume; nil leaves them unchanged. Returns no body.
+	if err := timersClient.ResumeTimer(ctx, timerID, nil); err != nil {
 		return fmt.Errorf("error resuming timer: %w", err)
 	}
 
 	// Display success message
 	fmt.Fprintf(os.Stdout, "Timer resumed successfully!\n\n")
-	fmt.Fprintf(os.Stdout, "Timer ID:    %s\n", updatedTimer.ID)
+	fmt.Fprintf(os.Stdout, "Timer ID:    %s\n", timerID)
 	fmt.Fprintf(os.Stdout, "Name:        %s\n", timer.Name)
-	fmt.Fprintf(os.Stdout, "Status:      %s\n", updatedTimer.Status)
-	if updatedTimer.NextDue != nil {
-		fmt.Fprintf(os.Stdout, "Next Run:    %s\n", updatedTimer.NextDue.Format(time.RFC3339))
-	}
 
 	return nil
 }

--- a/cmd/timer/show.go
+++ b/cmd/timer/show.go
@@ -93,11 +93,8 @@ func runShowTimer(cmd *cobra.Command, args []string) error {
 		// Text output - human readable
 		fmt.Printf("Timer Information\n")
 		fmt.Printf("=================\n\n")
-		fmt.Printf("Timer ID:    %s\n", timer.ID)
+		fmt.Printf("Timer ID:    %s\n", timer.JobID)
 		fmt.Printf("Name:        %s\n", timer.Name)
-		if timer.Callback != nil {
-			fmt.Printf("Type:        %s\n", timer.Callback.Type)
-		}
 		fmt.Printf("Status:      %s\n", timer.Status)
 
 		fmt.Printf("\nSchedule\n")
@@ -106,38 +103,35 @@ func runShowTimer(cmd *cobra.Command, args []string) error {
 			if timer.Schedule.Type != "" {
 				fmt.Printf("Schedule Type: %s\n", timer.Schedule.Type)
 			}
-			if timer.Schedule.Interval != nil {
-				fmt.Printf("Interval:      %s\n", *timer.Schedule.Interval)
+			if timer.Schedule.Datetime != "" {
+				fmt.Printf("Run At:        %s\n", timer.Schedule.Datetime)
 			}
-			if timer.Schedule.CronExpression != nil {
-				fmt.Printf("Cron:          %s\n", *timer.Schedule.CronExpression)
+			if timer.Schedule.IntervalSeconds > 0 {
+				fmt.Printf("Interval:      %ds\n", timer.Schedule.IntervalSeconds)
 			}
-			if timer.Schedule.Timezone != nil {
-				fmt.Printf("Timezone:      %s\n", *timer.Schedule.Timezone)
+			if timer.Schedule.Start != "" {
+				fmt.Printf("Start Time:    %s\n", timer.Schedule.Start)
 			}
-			if timer.Schedule.StartTime != nil {
-				fmt.Printf("Start Time:    %s\n", timer.Schedule.StartTime.Format(time.RFC3339))
-			}
-			if timer.Schedule.EndTime != nil {
-				fmt.Printf("End Time:      %s\n", timer.Schedule.EndTime.Format(time.RFC3339))
+			if timer.Schedule.End != nil && timer.Schedule.End.Datetime != "" {
+				fmt.Printf("End Time:      %s\n", timer.Schedule.End.Datetime)
 			}
 		}
 
 		fmt.Printf("\nTimestamps\n")
 		fmt.Printf("----------\n")
-		fmt.Printf("Created:       %s\n", timer.CreateTime.Format(time.RFC3339))
-		fmt.Printf("Last Update:   %s\n", timer.LastUpdate.Format(time.RFC3339))
-		if timer.LastRun != nil {
-			fmt.Printf("Last Run:      %s\n", timer.LastRun.Format(time.RFC3339))
-			fmt.Printf("Last Run Status: %s\n", timer.LastRunStatus)
+		if !timer.Created.IsZero() {
+			fmt.Printf("Created:       %s\n", timer.Created.Format(time.RFC3339))
 		}
-		if timer.NextDue != nil {
-			fmt.Printf("Next Run:      %s\n", timer.NextDue.Format(time.RFC3339))
+		if !timer.LastRun.IsZero() {
+			fmt.Printf("Last Run:      %s\n", timer.LastRun.Format(time.RFC3339))
+		}
+		if !timer.NextRun.IsZero() {
+			fmt.Printf("Next Run:      %s\n", timer.NextRun.Format(time.RFC3339))
 		}
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"ID", "Name", "CallbackType", "Status", "LastRunStatus"}
+		headers := []string{"JobID", "Name", "Status", "Schedule"}
 		if err := formatter.FormatOutput(timer, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/transfer/stream_access_point.go
+++ b/cmd/transfer/stream_access_point.go
@@ -3,28 +3,24 @@
 package transfer
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // StreamAccessPointCmd returns the stream-access-point subcommand group.
-// Stream Access Points provide real-time data stream access via Globus Streams.
-// Added in Python SDK v4.3.0.
+//
+// Globus Streams (tunnels and stream access points) is a Python SDK v4.3.0+
+// feature and is not part of the frozen v3 SDK this CLI builds against, so these
+// commands are not available.
 func StreamAccessPointCmd() *cobra.Command {
 	sapCmd := &cobra.Command{
 		Use:   "stream-access-point",
-		Short: "Commands for Globus Streams access points",
+		Short: "Commands for Globus Streams access points (unavailable)",
 		Long: `Commands for working with Globus Streams access points.
 
-Stream Access Points provide URL-based access to real-time data streams
-associated with a Globus Streams tunnel.
-
-Examples:
-  globus transfer stream-access-point show ACCESS_POINT_ID`,
+NOTE: Globus Streams is a newer API not included in the SDK version this CLI
+builds against, so these commands are not available.`,
 	}
 
 	sapCmd.AddCommand(streamAccessPointShowCmd())
@@ -35,40 +31,10 @@ Examples:
 func streamAccessPointShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show ACCESS_POINT_ID",
-		Short: "Show details of a Globus Streams access point",
-		Long: `Show details for a specific Globus Streams access point.
-
-An access point provides a URL for accessing a real-time data stream
-from a Globus Streams tunnel.
-
-Examples:
-  globus transfer stream-access-point show ACCESS_POINT_ID`,
-		Args: cobra.ExactArgs(1),
+		Short: "Show details of a Globus Streams access point (unavailable)",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			accessPointID := args[0]
-			profile := viper.GetString("profile")
-			client, err := newTransferClient(profile)
-			if err != nil {
-				return err
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			ap, err := client.GetStreamAccessPoint(ctx, accessPointID)
-			if err != nil {
-				return fmt.Errorf("failed to get stream access point: %w", err)
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "ID:           %s\n", ap.ID)
-			fmt.Fprintf(cmd.OutOrStdout(), "Tunnel ID:    %s\n", ap.TunnelID)
-			fmt.Fprintf(cmd.OutOrStdout(), "Endpoint ID:  %s\n", ap.EndpointID)
-			fmt.Fprintf(cmd.OutOrStdout(), "Path:         %s\n", ap.Path)
-			fmt.Fprintf(cmd.OutOrStdout(), "Access URL:   %s\n", ap.AccessURL)
-			if ap.ExpiresAt != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "Expires At:   %s\n", ap.ExpiresAt.Format(time.RFC3339))
-			}
-			return nil
+			return fmt.Errorf("Globus Streams is not supported by this SDK version")
 		},
 	}
 }

--- a/cmd/transfer/tunnel.go
+++ b/cmd/transfer/tunnel.go
@@ -3,383 +3,47 @@
 package transfer
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/transfer"
 )
 
 // TunnelCmd returns the tunnel subcommand group.
-// Globus Streams tunnels provide persistent channels for streaming data between
-// endpoints. Added in Python SDK v4.3.0 / Go SDK v4.3.0-1.
+//
+// Globus Streams tunnels are a Python SDK v4.3.0+ feature and are not part of
+// the frozen v3 SDK this CLI builds against, so these commands are not
+// available. The subcommands are retained so the help tree is stable, but each
+// returns a clear "unsupported" error.
 func TunnelCmd() *cobra.Command {
 	tunnelCmd := &cobra.Command{
 		Use:   "tunnel",
-		Short: "Commands for managing Globus Streams tunnels",
+		Short: "Commands for managing Globus Streams tunnels (unavailable)",
 		Long: `Commands for managing Globus Streams tunnels.
 
-Tunnels provide persistent channels for streaming data between Globus endpoints.
-They are the foundation of the Globus Streams service, enabling real-time data
-access without staging files through Transfer tasks.
-
-Examples:
-  globus transfer tunnel list
-  globus transfer tunnel create --name "My Tunnel" --source-endpoint EP_ID
-  globus transfer tunnel show TUNNEL_ID
-  globus transfer tunnel events TUNNEL_ID`,
+NOTE: Globus Streams is a newer API not included in the SDK version this CLI
+builds against, so these commands are not available.`,
 	}
 
 	tunnelCmd.AddCommand(
-		tunnelListCmd(),
-		tunnelCreateCmd(),
-		tunnelShowCmd(),
-		tunnelUpdateCmd(),
-		tunnelDeleteCmd(),
-		tunnelEventsCmd(),
+		tunnelUnsupportedCmd("list", "List Globus Streams tunnels"),
+		tunnelUnsupportedCmd("create", "Create a Globus Streams tunnel"),
+		tunnelUnsupportedCmd("show", "Show a Globus Streams tunnel"),
+		tunnelUnsupportedCmd("update", "Update a Globus Streams tunnel"),
+		tunnelUnsupportedCmd("delete", "Delete a Globus Streams tunnel"),
+		tunnelUnsupportedCmd("events", "Show events for a Globus Streams tunnel"),
 	)
 
 	return tunnelCmd
 }
 
-// newTransferClient is a helper that loads credentials and returns a ready transfer client.
-func newTransferClient(profile string) (*transfer.Client, error) {
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return nil, fmt.Errorf("not logged in: %w", err)
-	}
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return nil, fmt.Errorf("token is expired, please login again")
-	}
-	if _, err = config.LoadClientConfig(); err != nil {
-		return nil, fmt.Errorf("failed to load client configuration: %w", err)
-	}
-	coreAuthorizer := authorizers.ToCore(authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken))
-	client, err := transfer.NewClient(transfer.WithAuthorizer(coreAuthorizer))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create transfer client: %w", err)
-	}
-	return client, nil
-}
-
-// tunnelListCmd returns the tunnel list command.
-func tunnelListCmd() *cobra.Command {
-	var tunnelLimit int
-	var tunnelMarker string
-
-	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List Globus Streams tunnels",
-		Long: `List Globus Streams tunnels owned by the current user.
-
-Examples:
-  globus transfer tunnel list
-  globus transfer tunnel list --limit 50`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			profile := viper.GetString("profile")
-			client, err := newTransferClient(profile)
-			if err != nil {
-				return err
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			opts := &transfer.ListTunnelsOptions{Limit: tunnelLimit, Marker: tunnelMarker}
-			list, err := client.ListTunnels(ctx, opts)
-			if err != nil {
-				return fmt.Errorf("failed to list tunnels: %w", err)
-			}
-
-			format := viper.GetString("format")
-			formatter := output.NewFormatter(format, cmd.OutOrStdout())
-			headers := []string{"ID", "DisplayName", "Status", "SourceEndpointID", "SourcePath"}
-
-			type tunnelEntry struct {
-				ID               string
-				DisplayName      string
-				Status           string
-				SourceEndpointID string
-				SourcePath       string
-			}
-			entries := make([]tunnelEntry, 0, len(list.Tunnels))
-			for _, t := range list.Tunnels {
-				entries = append(entries, tunnelEntry{
-					ID:               t.ID,
-					DisplayName:      t.DisplayName,
-					Status:           t.Status,
-					SourceEndpointID: t.SourceEndpointID,
-					SourcePath:       t.SourcePath,
-				})
-			}
-			return formatter.FormatOutput(entries, headers)
-		},
-	}
-
-	cmd.Flags().IntVar(&tunnelLimit, "limit", 25, "Maximum number of tunnels to return")
-	cmd.Flags().StringVar(&tunnelMarker, "marker", "", "Pagination marker for next page")
-	return cmd
-}
-
-// tunnelCreateCmd returns the tunnel create command.
-func tunnelCreateCmd() *cobra.Command {
-	var name string
-	var sourceEndpoint string
-	var sourcePath string
-	var expiresIn int
-
-	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a new Globus Streams tunnel",
-		Long: `Create a new Globus Streams tunnel.
-
-A tunnel provides a persistent channel for streaming data from a source endpoint.
-
-Examples:
-  globus transfer tunnel create --name "My Tunnel" --source-endpoint EP_ID
-  globus transfer tunnel create --name "My Tunnel" --source-endpoint EP_ID \
-    --source-path /data/streams --expires-in 3600`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			profile := viper.GetString("profile")
-			client, err := newTransferClient(profile)
-			if err != nil {
-				return err
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			data := &transfer.CreateTunnelData{
-				DisplayName:      name,
-				SourceEndpointID: sourceEndpoint,
-				SourcePath:       sourcePath,
-			}
-			if expiresIn > 0 {
-				data.ExpiresIn = &expiresIn
-			}
-
-			tunnel, err := client.CreateTunnel(ctx, data)
-			if err != nil {
-				return fmt.Errorf("failed to create tunnel: %w", err)
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "Tunnel created successfully!\n\n")
-			fmt.Fprintf(cmd.OutOrStdout(), "ID:               %s\n", tunnel.ID)
-			fmt.Fprintf(cmd.OutOrStdout(), "Display Name:     %s\n", tunnel.DisplayName)
-			fmt.Fprintf(cmd.OutOrStdout(), "Status:           %s\n", tunnel.Status)
-			fmt.Fprintf(cmd.OutOrStdout(), "Source Endpoint:  %s\n", tunnel.SourceEndpointID)
-			if tunnel.SourcePath != "" {
-				fmt.Fprintf(cmd.OutOrStdout(), "Source Path:      %s\n", tunnel.SourcePath)
-			}
-			if tunnel.ExpiresAt != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "Expires At:       %s\n", tunnel.ExpiresAt.Format(time.RFC3339))
-			}
-			return nil
-		},
-	}
-
-	cmd.Flags().StringVar(&name, "name", "", "Display name for the tunnel (required)")
-	cmd.Flags().StringVar(&sourceEndpoint, "source-endpoint", "", "Source endpoint ID (required)")
-	cmd.Flags().StringVar(&sourcePath, "source-path", "", "Path on the source endpoint")
-	cmd.Flags().IntVar(&expiresIn, "expires-in", 0, "Tunnel lifetime in seconds (0 = no expiration)")
-	cmd.MarkFlagRequired("name")
-	cmd.MarkFlagRequired("source-endpoint")
-	return cmd
-}
-
-// tunnelShowCmd returns the tunnel show command.
-func tunnelShowCmd() *cobra.Command {
+// tunnelUnsupportedCmd builds a placeholder subcommand that reports the feature
+// is unavailable in this SDK version.
+func tunnelUnsupportedCmd(use, short string) *cobra.Command {
 	return &cobra.Command{
-		Use:   "show TUNNEL_ID",
-		Short: "Show details of a Globus Streams tunnel",
-		Long: `Show details for a specific Globus Streams tunnel.
-
-Examples:
-  globus transfer tunnel show TUNNEL_ID`,
-		Args: cobra.ExactArgs(1),
+		Use:   use,
+		Short: short + " (unavailable)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tunnelID := args[0]
-			profile := viper.GetString("profile")
-			client, err := newTransferClient(profile)
-			if err != nil {
-				return err
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			tunnel, err := client.GetTunnel(ctx, tunnelID)
-			if err != nil {
-				return fmt.Errorf("failed to get tunnel: %w", err)
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "ID:               %s\n", tunnel.ID)
-			fmt.Fprintf(cmd.OutOrStdout(), "Display Name:     %s\n", tunnel.DisplayName)
-			fmt.Fprintf(cmd.OutOrStdout(), "Owner:            %s\n", tunnel.Owner)
-			fmt.Fprintf(cmd.OutOrStdout(), "Status:           %s\n", tunnel.Status)
-			fmt.Fprintf(cmd.OutOrStdout(), "Source Endpoint:  %s\n", tunnel.SourceEndpointID)
-			if tunnel.SourcePath != "" {
-				fmt.Fprintf(cmd.OutOrStdout(), "Source Path:      %s\n", tunnel.SourcePath)
-			}
-			if tunnel.CreatedAt != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "Created At:       %s\n", tunnel.CreatedAt.Format(time.RFC3339))
-			}
-			if tunnel.UpdatedAt != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "Updated At:       %s\n", tunnel.UpdatedAt.Format(time.RFC3339))
-			}
-			if tunnel.ExpiresAt != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "Expires At:       %s\n", tunnel.ExpiresAt.Format(time.RFC3339))
-			}
-			return nil
+			return fmt.Errorf("Globus Streams tunnels are not supported by this SDK version")
 		},
 	}
-}
-
-// tunnelUpdateCmd returns the tunnel update command.
-func tunnelUpdateCmd() *cobra.Command {
-	var name string
-
-	cmd := &cobra.Command{
-		Use:   "update TUNNEL_ID",
-		Short: "Update a Globus Streams tunnel",
-		Long: `Update the display name of a Globus Streams tunnel.
-
-Examples:
-  globus transfer tunnel update TUNNEL_ID --name "New Name"`,
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			tunnelID := args[0]
-			profile := viper.GetString("profile")
-			client, err := newTransferClient(profile)
-			if err != nil {
-				return err
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			data := &transfer.UpdateTunnelData{}
-			if cmd.Flags().Changed("name") {
-				data.DisplayName = name
-			}
-
-			tunnel, err := client.UpdateTunnel(ctx, tunnelID, data)
-			if err != nil {
-				return fmt.Errorf("failed to update tunnel: %w", err)
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "Tunnel updated successfully!\n\n")
-			fmt.Fprintf(cmd.OutOrStdout(), "ID:           %s\n", tunnel.ID)
-			fmt.Fprintf(cmd.OutOrStdout(), "Display Name: %s\n", tunnel.DisplayName)
-			fmt.Fprintf(cmd.OutOrStdout(), "Status:       %s\n", tunnel.Status)
-			return nil
-		},
-	}
-
-	cmd.Flags().StringVar(&name, "name", "", "New display name for the tunnel")
-	return cmd
-}
-
-// tunnelDeleteCmd returns the tunnel delete command.
-func tunnelDeleteCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "delete TUNNEL_ID",
-		Short: "Delete a Globus Streams tunnel",
-		Long: `Delete a Globus Streams tunnel permanently.
-
-Examples:
-  globus transfer tunnel delete TUNNEL_ID`,
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			tunnelID := args[0]
-			profile := viper.GetString("profile")
-			client, err := newTransferClient(profile)
-			if err != nil {
-				return err
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			if err := client.DeleteTunnel(ctx, tunnelID); err != nil {
-				return fmt.Errorf("failed to delete tunnel: %w", err)
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "Tunnel %s deleted successfully.\n", tunnelID)
-			return nil
-		},
-	}
-}
-
-// tunnelEventsCmd returns the tunnel events command.
-func tunnelEventsCmd() *cobra.Command {
-	var eventsLimit int
-	var eventsMarker string
-
-	cmd := &cobra.Command{
-		Use:   "events TUNNEL_ID",
-		Short: "List events for a Globus Streams tunnel",
-		Long: `List events associated with a Globus Streams tunnel.
-
-Events record state changes and activity for a tunnel over its lifetime.
-Added in Python SDK v4.4.0.
-
-Examples:
-  globus transfer tunnel events TUNNEL_ID
-  globus transfer tunnel events TUNNEL_ID --limit 100`,
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			tunnelID := args[0]
-			profile := viper.GetString("profile")
-			client, err := newTransferClient(profile)
-			if err != nil {
-				return err
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			opts := &transfer.ListTunnelEventsOptions{Limit: eventsLimit, Marker: eventsMarker}
-			eventList, err := client.GetTunnelEvents(ctx, tunnelID, opts)
-			if err != nil {
-				return fmt.Errorf("failed to get tunnel events: %w", err)
-			}
-
-			format := viper.GetString("format")
-			formatter := output.NewFormatter(format, cmd.OutOrStdout())
-			headers := []string{"ID", "Code", "Description", "OccurredAt"}
-
-			type eventEntry struct {
-				ID          string
-				Code        string
-				Description string
-				OccurredAt  string
-			}
-			entries := make([]eventEntry, 0, len(eventList.Events))
-			for _, e := range eventList.Events {
-				occurredAt := ""
-				if e.OccurredAt != nil {
-					occurredAt = e.OccurredAt.Format(time.RFC3339)
-				}
-				entries = append(entries, eventEntry{
-					ID:          e.ID,
-					Code:        e.Code,
-					Description: e.Description,
-					OccurredAt:  occurredAt,
-				})
-			}
-			return formatter.FormatOutput(entries, headers)
-		},
-	}
-
-	cmd.Flags().IntVar(&eventsLimit, "limit", 25, "Maximum number of events to return")
-	cmd.Flags().StringVar(&eventsMarker, "marker", "", "Pagination marker for next page")
-	return cmd
 }


### PR DESCRIPTION
## Summary

Building the CLI against the parity-audited `globus-go-sdk` v3 surface exposed
~52 breakages across 28 files. **Every one traced to a method the CLI called
that compiled but was wire-broken** — phantom methods that hit URLs the real
Globus API never exposed (removed during the SDK's parity audit against Python
globus-sdk 3.65.0), or fields/signatures that changed. This migrates each
command to the corrected surface.

## Changes by service

- **groups**: `ListGroups` → `GetMyGroups`; `AddMember`/`RemoveMember`/
  `ListMembers` → `BatchMembershipAction` / `GetGroup(include=memberships)`;
  `GetGroup` now takes `*GetGroupOptions`.
- **compute**: the client is now a passthrough `map[string]interface{}` surface.
  `GetEndpoint(s)`/`GetFunction`/`GetTask`/`RegisterFunction`/`DeleteFunction`
  adapted to maps; `GetEndpoints` returns `[]map`. Commands with **no upstream
  route** (`function list`/`update`, `task list`/`cancel`/`run`) now return a
  clear "not supported by the Compute API" error instead of calling a
  nonexistent method. (`task run` needs Globus Compute-serialized arguments the
  CLI can't produce; documented accordingly.)
- **flows**: `RunRequest.Input` → `Body`; `RunLogEntry.CreatedAt` → `Time`.
- **search**: `index_list` is not paginated upstream (dropped `HasMore`);
  `DeleteDocumentsResponse.Task` → `.TaskID`; task-status output trimmed to the
  real wire fields.
- **timers**: cron scheduling removed (not in the API) → once/recurring
  `Schedule` + `CreateTimer`; `FlowTimer` reshaped; `Timer.ID`→`JobID`,
  `NextDue`→`NextRun`; `Pause`/`Resume` return only `error` (`Resume` takes a
  `*bool` update-credentials flag).
- **transfer**: Streams tunnels + stream access points are a Python SDK v4.3.0+
  feature absent from the frozen v3 SDK; those command trees are retained as
  clear "unavailable" stubs so the help tree stays stable.

Removed-with-no-replacement commands were made to fail loudly and honestly
rather than silently mislead — several of them would have 404'd at runtime
before this change.

## Testing

`go build`/`go vet`/`go test ./...` all clean (via the existing `go.work`, which
already points at the local SDK). The binary runs and unsupported commands emit
a clear error, e.g.:

```
$ globus compute task list
Error: listing tasks is not supported by the Globus Compute API; use "globus compute task show TASK_ID"
```

## Caveats

- **Not verified against live Globus.** This is compile/test-verified only; the
  migrated commands' runtime behavior against the real API has not been
  exercised with credentials.
- **Depends on the unreleased SDK `main`.** The corresponding SDK changes are on
  `main` but not yet tagged, so this builds via `go.work`; a released SDK version
  + `go.mod` bump should follow once the SDK is tagged.