### PR TITLE
docs: Python Globus CLI parity comparison

### DIFF
--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -1,0 +1,95 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors -->
+
+# Parity with the upstream Python Globus CLI
+
+This tracks the Go CLI's command coverage against the reference
+[Globus CLI (Python)](https://github.com/globus/globus-cli). It is a
+functional comparison, not a 1:1 command-path map — the two CLIs organize
+commands differently (the Go CLI nests task/endpoint commands under each
+service; the Python CLI is flatter, e.g. top-level `task`, `bookmark`,
+`collection`, `endpoint`).
+
+- **Python globus-cli compared:** 3.42.0 (latest at time of writing), 164 commands.
+- **Go CLI:** ~112 command paths across auth, transfer, search, groups, flows,
+  compute, timer, config.
+
+Note the version numbers are independent: the Go CLI tracks the Globus **SDK**
+(Python globus-sdk 3.65.0), while the Python **CLI** versions separately (3.42.0).
+
+## Coverage by area
+
+| Area | Python CLI | Go CLI | Status |
+|------|-----------|--------|--------|
+| Login / logout / whoami | ✅ | ✅ (`auth login/logout/whoami`) | Covered |
+| Identity lookup | `get-identities` | ✅ (`auth identities lookup`) | Covered |
+| Transfer submit / ls / mkdir / rename / rm / stat | ✅ | Partial — `cp`, `ls`, `mkdir`, `rm`; **no `rename`, no `stat`** | Gap: rename, stat |
+| Tasks (show/list/cancel/wait/event-list/pause-info/update) | ✅ (8) | Partial — show/list/cancel/wait; **no event-list, pause-info, update, generate-submission-id** | Gap |
+| Endpoint search / show / update / delete | ✅ | Partial — search/show/list; **no update/delete** | Gap |
+| Endpoint roles | ✅ (create/delete/list/show) | ❌ none | Gap |
+| Endpoint permissions (ACLs) | ✅ (5) | ❌ none | Gap |
+| Bookmarks | ✅ (5) | ❌ none | Gap |
+| Collections / GCS management | ✅ (`collection`, `gcs`, 32 cmds) | ❌ none | Gap (no SDK support) |
+| GCP (Connect Personal) | ✅ (6) | ❌ none | Gap (no SDK support) |
+| Streams / tunnels | ✅ (8) | Stubs (report "unavailable") | Gap (not in v3 SDK) |
+| Search (index/query/ingest/task/role/subject) | ✅ (14) | ✅ comparable | Covered |
+| Groups (member/role/policy/invite/join/leave) | ✅ (19) | Partial — create/delete/list/show/update, member add/invite/list/remove, join/leave; **no group role commands** | Mostly covered |
+| Flows (create/run/list/show/update/validate/logs) | ✅ (17) | ✅ comparable | Covered |
+| Timers | ✅ (7) | ✅ (create/list/show/pause/resume/delete) | Covered |
+| `api` raw passthrough | ✅ (7 services) | ❌ none | Gap |
+| `session` (consent/show/update) | ✅ (3) | ❌ none | Gap |
+| Compute | ❌ (not in Python CLI) | ✅ (endpoint/function/task) | Go-only extension |
+
+## Gap classification
+
+Two kinds of gap, important to distinguish:
+
+### A. CLI gaps the Go SDK already supports (exposing them is CLI-only work)
+
+The v3 SDK parity audit added the wire methods for most of these; the CLI simply
+hasn't wired up commands yet:
+
+- **Bookmarks** — SDK: `BookmarkList`/`CreateBookmark`/`GetBookmark`/
+  `UpdateBookmark`/`DeleteBookmark`.
+- **Endpoint roles** — SDK: `EndpointRoleList`/`AddEndpointRole`/
+  `GetEndpointRole`/`DeleteEndpointRole`.
+- **Endpoint ACLs / permissions** — SDK: `EndpointACLList`/`GetEndpointACLRule`/
+  `AddEndpointACLRule`/`UpdateEndpointACLRule`/`DeleteEndpointACLRule`.
+- **Endpoint update/delete, set-subscription-id, shared-endpoint list** — SDK:
+  `UpdateEndpoint`/`DeleteEndpoint`/`SetSubscriptionID`/`MySharedEndpointList`/
+  `GetSharedEndpointList`.
+- **Transfer `stat`** — SDK: `OperationStat`. **`rename`** — SDK: `Rename`.
+- **Task `event-list`/`pause-info`/`update`** — SDK: `TaskEventList`/
+  `TaskPauseInfo`/`UpdateTask` (+ `TaskSuccessfulTransfers`/`TaskSkippedErrors`).
+- **Endpoint-manager admin surface** — SDK: full `EndpointManager*` family.
+- **Group roles**, **session/consents** — SDK: groups membership actions and
+  auth `GetConsents`/`GetIdentities` exist.
+
+### B. Gaps with no v3 SDK support (need SDK work first, or are out of scope)
+
+- **GCS / collections management** (`collection`, `gcs`, ~32 commands) — there is
+  **no v3 `gcs` service** in the Go SDK. The v4 SDK module has a `gcs` service;
+  full support would require either a v4-based CLI or a v3 gcs port.
+- **GCP (Globus Connect Personal)** — local-agent management; not an SDK API.
+- **Streams / tunnels** — a Python globus-sdk v4.3.0+ feature, absent from the
+  frozen v3 SDK. Present as "unavailable" stubs.
+- **`api` raw passthrough** — convenience for arbitrary API calls; no SDK method,
+  would be a thin HTTP wrapper.
+
+## Compute is a Go-only extension
+
+The Go CLI exposes a `compute` command tree; the Python CLI has **no** compute
+commands (Globus Compute has its own separate `globus-compute` CLI). The Go
+compute commands are limited by the Compute web API (no list/cancel/run of tasks
+or functions server-side — those require the Globus Compute serialization SDK).
+
+## Summary
+
+The Go CLI covers the **core data-management workflows** (transfer, search,
+groups, flows, timers, auth) at rough parity with the Python CLI's most-used
+commands, plus a compute extension. The material gaps are:
+
+1. **Endpoint administration** (roles, ACLs/permissions, update/delete) and
+   **bookmarks** — all SDK-supported; CLI wiring is the remaining work.
+2. **GCS/collections and GCP** — larger, need a v4-gcs path or are out of scope.
+3. **`api` passthrough** and **`session`** — convenience features.


### PR DESCRIPTION
## Summary

Per request to check the Go CLI against the upstream Python Globus CLI's current
version and functionality. Adds `docs/PYTHON_CLI_PARITY.md`, a functional
coverage comparison.

## Method

- Compared against the installed **Python globus-cli 3.42.0** (confirmed latest),
  enumerated via `globus list-commands` — **164 commands**.
- Walked the Go CLI's full command tree from `--help` — **~112 command paths**.
- The two organize commands differently (Go nests under services, e.g.
  `transfer task show`; Python is flatter, e.g. `task show`), so this is a
  capability comparison, not a path-by-path map.

## Key findings

**Covered at rough parity:** transfer core (cp/ls/mkdir/rm), search, groups,
flows, timers, auth/login/whoami/identities. Plus a **compute** tree that the
Python CLI doesn't have (Compute has its own separate CLI).

**Gaps, split by whether the SDK already supports them:**

- **(A) CLI-only work — the v3 SDK already has the methods:** bookmarks, endpoint
  roles, endpoint ACLs/permissions, endpoint update/delete/set-subscription-id,
  transfer `rename` and `stat`, task `event-list`/`pause-info`/`update`, and the
  whole endpoint-manager admin surface. These are verified present in the SDK
  (e.g. `OperationStat`, `Rename`, `BookmarkList`, `EndpointRoleList`,
  `EndpointACLList`, `EndpointManager*`).
- **(B) Need SDK work or out of scope:** GCS/collections management (~32 Python
  commands — **no v3 `gcs` service**; v4 SDK has one), GCP (local agent, not an
  API), Streams/tunnels (v4.3.0+ only — currently "unavailable" stubs), `api`
  raw passthrough, and `session`/consents.

## Caveat

This is a **command-surface** comparison (what commands exist), verified by
walking both CLIs' help and checking claimed SDK methods exist. It is not a
behavioral/flag-level audit — individual command options and output formats were
not compared field-by-field, and nothing was run against live Globus.