### PR TITLE
fix(cli): unsupported pagination/orderby on list commands (found by dogfooding)

### DIFF
--- a/cmd/flows/list.go
+++ b/cmd/flows/list.go
@@ -18,9 +18,9 @@ import (
 )
 
 var (
-	listLimit  int
-	listOffset int
-	listFilter string
+	listLimit   int
+	listOffset  int
+	listFilter  string
 	listOrderBy string
 )
 
@@ -49,8 +49,12 @@ Examples:
 }
 
 func init() {
-	ListCmd.Flags().IntVar(&listLimit, "limit", 25, "Maximum number of flows to return")
-	ListCmd.Flags().IntVar(&listOffset, "offset", 0, "Offset for pagination")
+	// list_flows is marker-paginated; limit/offset are not accepted (kept as
+	// deprecated no-ops for compatibility).
+	ListCmd.Flags().IntVar(&listLimit, "limit", 0, "Deprecated: list_flows is marker-paginated")
+	ListCmd.Flags().IntVar(&listOffset, "offset", 0, "Deprecated: list_flows is marker-paginated")
+	_ = ListCmd.Flags().MarkDeprecated("limit", "list_flows is marker-paginated")
+	_ = ListCmd.Flags().MarkDeprecated("offset", "list_flows is marker-paginated")
 	ListCmd.Flags().StringVar(&listFilter, "filter", "", "Filter flows by text")
 	ListCmd.Flags().StringVar(&listOrderBy, "orderby", "created_at", "Order results by field (created_at, updated_at, title)")
 }
@@ -92,10 +96,9 @@ func runFlowsList(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Build list options
+	// Build list options. list_flows is marker-paginated and rejects
+	// limit/offset (HTTP 422), so only filter/orderby are sent.
 	options := &flows.ListFlowsOptions{
-		Limit:   listLimit,
-		Offset:  listOffset,
 		OrderBy: listOrderBy,
 	}
 	if listFilter != "" {

--- a/cmd/flows/run_list.go
+++ b/cmd/flows/run_list.go
@@ -53,11 +53,16 @@ Examples:
 }
 
 func init() {
-	RunListCmd.Flags().IntVar(&runListLimit, "limit", 25, "Maximum number of runs to return")
-	RunListCmd.Flags().IntVar(&runListOffset, "offset", 0, "Offset for pagination")
+	// list_runs is marker-paginated; limit/offset are not accepted.
+	RunListCmd.Flags().IntVar(&runListLimit, "limit", 0, "Deprecated: list_runs is marker-paginated")
+	RunListCmd.Flags().IntVar(&runListOffset, "offset", 0, "Deprecated: list_runs is marker-paginated")
+	_ = RunListCmd.Flags().MarkDeprecated("limit", "list_runs is marker-paginated")
+	_ = RunListCmd.Flags().MarkDeprecated("offset", "list_runs is marker-paginated")
 	RunListCmd.Flags().StringVar(&runListFlowID, "flow-id", "", "Filter by flow ID")
 	RunListCmd.Flags().StringVar(&runListStatus, "status", "", "Filter by status (ACTIVE, SUCCEEDED, FAILED, INACTIVE)")
-	RunListCmd.Flags().StringVar(&runListOrderBy, "orderby", "created_at DESC", "Order results by field")
+	// Runs are ordered by run fields (e.g. start_time); created_at is a flow
+	// field and is rejected here.
+	RunListCmd.Flags().StringVar(&runListOrderBy, "orderby", "start_time DESC", "Order results by field (e.g. start_time DESC)")
 }
 
 func runFlowsRunList(cmd *cobra.Command, args []string) error {
@@ -97,10 +102,9 @@ func runFlowsRunList(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Build list options
+	// Build list options. list_runs is marker-paginated and rejects
+	// limit/offset (HTTP 422), so only orderby/filters are sent.
 	options := &flows.ListRunsOptions{
-		Limit:   runListLimit,
-		Offset:  runListOffset,
 		OrderBy: runListOrderBy,
 	}
 	if runListFlowID != "" {

--- a/cmd/search/index_list.go
+++ b/cmd/search/index_list.go
@@ -43,8 +43,12 @@ Examples:
 }
 
 func init() {
-	IndexListCmd.Flags().IntVar(&indexListLimit, "limit", 100, "Maximum number of indices to return")
-	IndexListCmd.Flags().IntVar(&indexListOffset, "offset", 0, "Offset for pagination")
+	// index_list is not paginated by the Search API, so these are no-ops kept
+	// for backward compatibility.
+	IndexListCmd.Flags().IntVar(&indexListLimit, "limit", 0, "Deprecated: index_list is not paginated")
+	IndexListCmd.Flags().IntVar(&indexListOffset, "offset", 0, "Deprecated: index_list is not paginated")
+	_ = IndexListCmd.Flags().MarkDeprecated("limit", "index_list is not paginated")
+	_ = IndexListCmd.Flags().MarkDeprecated("offset", "index_list is not paginated")
 }
 
 func runIndexList(cmd *cobra.Command, args []string) error {
@@ -84,13 +88,10 @@ func runIndexList(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// List indices
-	options := &search.ListIndexesOptions{
-		Limit:  indexListLimit,
-		Offset: indexListOffset,
-	}
-
-	indexList, err := searchClient.ListIndexes(ctx, options)
+	// List indices. The Search index_list endpoint is NOT paginated — sending
+	// limit/offset returns HTTP 400 — so no options are passed. The --limit and
+	// --offset flags are retained as deprecated no-ops for compatibility.
+	indexList, err := searchClient.ListIndexes(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("error listing indices: %w", err)
 	}


### PR DESCRIPTION
## Summary

A second live-dogfooding pass (client-credentials token against real Globus)
found a consistent class of bug in list commands: **sending query params the API
rejects**, all invisible to mock tests.

| Command | Live result | Cause | Fix |
|---|---|---|---|
| `search index list` | HTTP 400 | `index_list` is not paginated; sent `--limit 100` | drop limit/offset (deprecated no-op flags) |
| `flows list` | HTTP 422 | `list_flows` is marker-paginated; sent `--limit 25` | drop limit/offset; keep filter/orderby |
| `flows run list` | HTTP 422 | `list_runs` marker-paginated; sent `--limit 25` | drop limit/offset |
| `flows run list` | HTTP 422 (also) | default `--orderby created_at` — a flow field, invalid for runs | default → `start_time DESC` |

## Verification (live)

After the fixes, all three succeed with **default flags** against real Globus:
- `search index list` → returns indices (empty for the client-creds identity, correctly)
- `flows list` → returns the flow
- `flows run list` → now a clean **403** permission boundary for the test identity,
  rather than a malformed-request 422

`go build/vet/test ./...` green.

## Context

Follows the keywords fix (globus-go-sdk#54) from the first dogfooding pass. These
are CLI-side (wrong default params); the SDK correctly only sends the fields it's
given. Confirms the value of dogfooding as a standing step — every list command
had a latent default that broke on the real API.