### PR TITLE
fix(cli): search query uses GET (was a malformed POST → HTTP 400)

### DIFF
--- a/cmd/search/query.go
+++ b/cmd/search/query.go
@@ -19,9 +19,9 @@ import (
 )
 
 var (
-	queryString string
-	queryLimit  int
-	queryOffset int
+	queryString   string
+	queryLimit    int
+	queryOffset   int
 	queryAdvanced bool
 )
 
@@ -99,18 +99,11 @@ func runSearchQuery(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Build search request
-	searchRequest := &search.SearchRequest{
-		IndexID: indexID,
-		Query:   queryString,
-		Options: &search.SearchOptions{
-			Limit:  queryLimit,
-			Offset: queryOffset,
-		},
-	}
-
-	// Execute search
-	response, err := searchClient.Search(ctx, searchRequest)
+	// Execute a simple search. Upstream models this as GET
+	// /v1/index/{id}/search with q/offset/limit/advanced query params
+	// (GetSearch), not a POST body — the POST Search sends a malformed body and
+	// returns HTTP 400.
+	response, err := searchClient.GetSearch(ctx, indexID, queryString, queryOffset, queryLimit, queryAdvanced)
 	if err != nil {
 		return fmt.Errorf("error executing search: %w", err)
 	}


### PR DESCRIPTION
## Summary

Third live-dogfooding find. `globus search query` returned **HTTP 400** against
real Globus. The command called `searchClient.Search`, which POSTs the whole
`SearchRequest` struct (`{index_id, q, options:{...}}`) — but the Search API's
simple query is a **GET** `/v1/index/{id}/search` with `q`/`offset`/`limit`/
`advanced` query params. The POST body was malformed (redundant `index_id`, a
nested `options` object whose fields have `url:` tags that serialize as Go field
names), so the API rejected it.

## Fix

Switch `search query` to `searchClient.GetSearch` — the correct GET-based method
already present in the SDK (added during the parity audit).

## Verification (live)

- Before: 400 on any query.
- After: request is well-formed. A missing index now returns **404
  NoSuchIndex** — **byte-for-byte the same outcome as the Python CLI** on the
  same input (confirmed side by side). A valid, accessible index returns results.

`go build/vet/test ./...` green.

## Note

The Go CLI's error text for the 404 is terser than Python's (which prints
request_id + `NotFound.NoSuchIndex`); richer API-error formatting is a Phase 6
parity item, tracked separately.