### PR TITLE
feat: migrate CLI service commands to v4 SDK + GlobusApp auth (Phase 2b)

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -200,19 +200,12 @@ func loadToken(profile string) (*TokenInfo, error) {
 	return &token, nil
 }
 
-// getTokenFilePath returns the path to the token file for a profile
+// getTokenFilePath returns the path to the legacy bridge token file for a
+// profile. It delegates to GetTokenFilePathFunc (utils.go) so the writer here
+// and the reader in LoadToken always agree on the location, and so both stay
+// distinct from the v4 GlobusApp store at "<profile>.json".
 func getTokenFilePath(profile string) (string, error) {
-	// Get the home directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("error getting home directory: %w", err)
-	}
-
-	// Create the token file path
-	tokensDir := filepath.Join(homeDir, ".globus-cli", "tokens")
-	tokenFile := filepath.Join(tokensDir, profile+".json")
-
-	return tokenFile, nil
+	return GetTokenFilePathFunc(profile)
 }
 
 // isTokenValid checks if a token is valid

--- a/cmd/auth/utils.go
+++ b/cmd/auth/utils.go
@@ -26,9 +26,12 @@ var GetTokenFilePathFunc = func(profile string) (string, error) {
 		return "", fmt.Errorf("error getting home directory: %w", err)
 	}
 
-	// Create the token file path
+	// Create the token file path. This is the *legacy* single-token bridge file
+	// used by commands not yet migrated to the v4 per-resource-server store. It
+	// deliberately lives at "<profile>-legacy.json" so it never collides with
+	// the v4 GlobusApp token store at "<profile>.json" (see pkg/globusauth).
 	tokensDir := filepath.Join(homeDir, ".globus-cli", "tokens")
-	tokenFile := filepath.Join(tokensDir, profile+".json")
+	tokenFile := filepath.Join(tokensDir, profile+"-legacy.json")
 
 	return tokenFile, nil
 }

--- a/cmd/auth/utils_test.go
+++ b/cmd/auth/utils_test.go
@@ -65,8 +65,9 @@ func TestGetTokenFilePath(t *testing.T) {
 		t.Fatalf("Error getting home directory: %v", err)
 	}
 
-	// Create a mock token file path
-	expectedPath := filepath.Join(homeDir, ".globus-cli", "tokens", "test-profile.json")
+	// The legacy bridge token file lives at "<profile>-legacy.json" so it does
+	// not collide with the v4 GlobusApp store at "<profile>.json".
+	expectedPath := filepath.Join(homeDir, ".globus-cli", "tokens", "test-profile-legacy.json")
 
 	// Test the function
 	tokenPath, err := GetTokenFilePathFunc("test-profile")

--- a/cmd/compute/client.go
+++ b/cmd/compute/client.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package compute
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/compute"
+)
+
+// getClient builds a v4 Compute client authorized for the current profile from
+// the per-resource-server GlobusApp token store. It replaces the previous
+// per-command recipe of loading the legacy token file and wrapping a static
+// authorizer. On a missing/expired token it returns an error advising login.
+func getClient(ctx context.Context) (*compute.Client, error) {
+	profile := viper.GetString("profile")
+
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	cfg, err := globusauth.ClientConfig(ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret, globusauth.ServiceCompute)
+	if err != nil {
+		return nil, fmt.Errorf("not logged in: %w", err)
+	}
+
+	client, err := compute.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create compute client: %w", err)
+	}
+	return client, nil
+}

--- a/cmd/compute/endpoint_list.go
+++ b/cmd/compute/endpoint_list.go
@@ -8,11 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/compute"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -59,41 +56,15 @@ func init() {
 }
 
 func runEndpointList(cmd *cobra.Command, args []string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Compute client authorized for the current profile.
+	computeClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// The Compute API returns a top-level array of endpoint documents. It has no
 	// server-side search/status/per-page filters, so those flags are applied

--- a/cmd/compute/endpoint_show.go
+++ b/cmd/compute/endpoint_show.go
@@ -8,11 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -38,41 +34,15 @@ Examples:
 func runEndpointShow(cmd *cobra.Command, args []string) error {
 	endpointID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Compute client authorized for the current profile.
+	computeClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get endpoint
 	endpoint, err := computeClient.GetEndpoint(ctx, endpointID)

--- a/cmd/compute/function_delete.go
+++ b/cmd/compute/function_delete.go
@@ -10,12 +10,7 @@ import (
 	"strings"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var functionDeleteYes bool
@@ -63,41 +58,15 @@ func runFunctionDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Compute client authorized for the current profile.
+	computeClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Delete function (returns the passthrough result document, ignored here)
 	if _, err = computeClient.DeleteFunction(ctx, functionID); err != nil {

--- a/cmd/compute/function_register.go
+++ b/cmd/compute/function_register.go
@@ -8,12 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -74,41 +69,15 @@ func runFunctionRegister(cmd *cobra.Command, args []string) error {
 		functionCode = registerCode
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Compute client authorized for the current profile.
+	computeClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Register function. The Compute API takes and returns open-ended documents.
 	function, err := computeClient.RegisterFunction(ctx, map[string]interface{}{

--- a/cmd/compute/function_show.go
+++ b/cmd/compute/function_show.go
@@ -8,11 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -38,41 +34,15 @@ Examples:
 func runFunctionShow(cmd *cobra.Command, args []string) error {
 	functionID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Compute client authorized for the current profile.
+	computeClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get function
 	function, err := computeClient.GetFunction(ctx, functionID)

--- a/cmd/compute/task_show.go
+++ b/cmd/compute/task_show.go
@@ -9,11 +9,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/compute"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -40,41 +36,15 @@ Examples:
 func runTaskShow(cmd *cobra.Command, args []string) error {
 	taskID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create compute client
-	computeClient, err := compute.NewClient(
-		compute.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create compute client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Compute client authorized for the current profile.
+	computeClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get task status (GET /v2/tasks/{id}); the response is an open-ended document.
 	taskStatus, err := computeClient.GetTask(ctx, taskID)

--- a/cmd/flows/client.go
+++ b/cmd/flows/client.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package flows
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/flows"
+)
+
+// getClient builds a v4 Flows client authorized for the current profile from the
+// per-resource-server GlobusApp token store. It replaces the previous per-command
+// recipe of loading the legacy token file and wrapping a static authorizer. On a
+// missing/expired token it returns an error advising login.
+func getClient(ctx context.Context) (*flows.Client, error) {
+	profile := viper.GetString("profile")
+
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	cfg, err := globusauth.ClientConfig(ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret, globusauth.ServiceFlows)
+	if err != nil {
+		return nil, fmt.Errorf("not logged in: %w", err)
+	}
+
+	client, err := flows.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create flows client: %w", err)
+	}
+	return client, nil
+}

--- a/cmd/flows/create.go
+++ b/cmd/flows/create.go
@@ -9,12 +9,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/flows"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -100,65 +96,23 @@ func runFlowsCreate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Build create request
-	request := &flows.FlowCreateRequest{
+	request := &flows.FlowCreate{
 		Title:       createTitle,
 		Description: createDescription,
 		Definition:  definition,
 		InputSchema: inputSchema,
 		Keywords:    createKeywords,
-		Public:      createPublic,
-	}
-
-	// Apply authentication policy if any policy flag was set
-	if createHighAssurance || createRequiredMFA || len(createSessionPolicies) > 0 {
-		policy := &flows.FlowAuthenticationPolicy{}
-		if createHighAssurance {
-			policy.HighAssurance = &createHighAssurance
-		}
-		if createRequiredMFA {
-			policy.RequiredMFA = &createRequiredMFA
-		}
-		if len(createSessionPolicies) > 0 {
-			policy.SessionPolicies = createSessionPolicies
-		}
-		request.AuthenticationPolicy = policy
 	}
 
 	// Create flow
@@ -171,9 +125,8 @@ func runFlowsCreate(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "Flow created successfully!\n\n")
 	fmt.Fprintf(os.Stdout, "Flow ID:   %s\n", flow.ID)
 	fmt.Fprintf(os.Stdout, "Title:     %s\n", flow.Title)
-	fmt.Fprintf(os.Stdout, "Owner:     %s\n", flow.FlowOwner)
-	fmt.Fprintf(os.Stdout, "Public:    %t\n", flow.Public)
-	fmt.Fprintf(os.Stdout, "Created:   %s\n", flow.CreatedAt.Format(time.RFC3339))
+	fmt.Fprintf(os.Stdout, "Owner:     %s\n", flow.OwnerID)
+	fmt.Fprintf(os.Stdout, "Created:   %s\n", flow.Created.Format(time.RFC3339))
 
 	return nil
 }

--- a/cmd/flows/delete.go
+++ b/cmd/flows/delete.go
@@ -10,12 +10,7 @@ import (
 	"strings"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var deleteYes bool
@@ -64,41 +59,15 @@ func runFlowsDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Delete flow
 	err = flowsClient.DeleteFlow(ctx, flowID)

--- a/cmd/flows/list.go
+++ b/cmd/flows/list.go
@@ -8,11 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/flows"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -60,49 +57,24 @@ func init() {
 }
 
 func runFlowsList(cmd *cobra.Command, args []string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Build list options. list_flows is marker-paginated and rejects
 	// limit/offset (HTTP 422), so only filter/orderby are sent.
-	options := &flows.ListFlowsOptions{
-		OrderBy: listOrderBy,
+	options := &flows.ListFlowsOptions{}
+	if listOrderBy != "" {
+		options.OrderBy = []string{listOrderBy}
 	}
 	if listFilter != "" {
-		options.Q = listFilter
+		options.FilterFulltext = listFilter
 	}
 
 	// List flows
@@ -121,12 +93,11 @@ func runFlowsList(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		fmt.Printf("%-36s  %-40s  %-8s  %-6s\n", "Flow ID", "Title", "Public", "Runs")
-		fmt.Printf("%s  %s  %s  %s\n",
+		fmt.Printf("%-36s  %-40s  %-36s\n", "Flow ID", "Title", "Owner")
+		fmt.Printf("%s  %s  %s\n",
 			"------------------------------------",
 			"----------------------------------------",
-			"--------",
-			"------")
+			"------------------------------------")
 
 		for _, flow := range flowList.Flows {
 			title := flow.Title
@@ -134,23 +105,17 @@ func runFlowsList(cmd *cobra.Command, args []string) error {
 				title = title[:37] + "..."
 			}
 
-			public := "No"
-			if flow.Public {
-				public = "Yes"
-			}
-
-			fmt.Printf("%-36s  %-40s  %-8s  %-6d\n",
+			fmt.Printf("%-36s  %-40s  %-36s\n",
 				flow.ID,
 				title,
-				public,
-				flow.RunCount)
+				flow.OwnerID)
 		}
 
 		fmt.Printf("\nTotal: %d flow(s)\n", len(flowList.Flows))
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"ID", "Title", "Description", "Public", "RunCount", "CreatedAt", "UpdatedAt"}
+		headers := []string{"ID", "Title", "Description", "OwnerID", "Created", "Updated"}
 		if err := formatter.FormatOutput(flowList.Flows, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/flows/run_cancel.go
+++ b/cmd/flows/run_cancel.go
@@ -8,12 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // RunCancelCmd represents the flows run cancel command
@@ -35,41 +30,15 @@ Examples:
 func runFlowsRunCancel(cmd *cobra.Command, args []string) error {
 	runID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Cancel run
 	err = flowsClient.CancelRun(ctx, runID)

--- a/cmd/flows/run_list.go
+++ b/cmd/flows/run_list.go
@@ -8,11 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/flows"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -66,58 +63,39 @@ func init() {
 }
 
 func runFlowsRunList(cmd *cobra.Command, args []string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Build list options. list_runs is marker-paginated and rejects
-	// limit/offset (HTTP 422), so only orderby/filters are sent.
-	options := &flows.ListRunsOptions{
-		OrderBy: runListOrderBy,
-	}
+	// limit/offset (HTTP 422), so only filters are sent.
+	options := &flows.ListRunsOptions{}
 	if runListFlowID != "" {
-		options.FlowID = runListFlowID
-	}
-	if runListStatus != "" {
-		options.Status = runListStatus
+		options.FilterFlowID = []string{runListFlowID}
 	}
 
 	// List runs
 	runList, err := flowsClient.ListRuns(ctx, options)
 	if err != nil {
 		return fmt.Errorf("error listing runs: %w", err)
+	}
+
+	// The v4 ListRunsOptions has no server-side status filter, so apply the
+	// --status filter client-side to preserve the previous behavior.
+	if runListStatus != "" {
+		filtered := runList.Runs[:0]
+		for _, run := range runList.Runs {
+			if run.Status == runListStatus {
+				filtered = append(filtered, run)
+			}
+		}
+		runList.Runs = filtered
 	}
 
 	// Format output
@@ -130,7 +108,7 @@ func runFlowsRunList(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		fmt.Printf("%-36s  %-36s  %-12s  %-20s\n", "Run ID", "Flow ID", "Status", "Created")
+		fmt.Printf("%-36s  %-36s  %-12s  %-20s\n", "Run ID", "Flow ID", "Status", "Started")
 		fmt.Printf("%s  %s  %s  %s\n",
 			"------------------------------------",
 			"------------------------------------",
@@ -142,14 +120,14 @@ func runFlowsRunList(cmd *cobra.Command, args []string) error {
 				run.RunID,
 				run.FlowID,
 				run.Status,
-				run.CreatedAt.Format("2006-01-02 15:04:05"))
+				run.StartTime.Format("2006-01-02 15:04:05"))
 		}
 
 		fmt.Printf("\nTotal: %d run(s)\n", len(runList.Runs))
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"RunID", "FlowID", "Status", "Label", "CreatedAt", "StartedAt", "CompletedAt", "UserID"}
+		headers := []string{"RunID", "FlowID", "FlowTitle", "Status", "Label", "RunOwner", "StartTime", "EndTime"}
 		if err := formatter.FormatOutput(runList.Runs, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/flows/run_show.go
+++ b/cmd/flows/run_show.go
@@ -9,11 +9,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -39,44 +35,18 @@ Examples:
 func runFlowsRunShow(cmd *cobra.Command, args []string) error {
 	runID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Get run
-	run, err := flowsClient.GetRun(ctx, runID)
+	run, err := flowsClient.GetRun(ctx, runID, nil)
 	if err != nil {
 		return fmt.Errorf("error getting run: %w", err)
 	}
@@ -98,35 +68,24 @@ func runFlowsRunShow(cmd *cobra.Command, args []string) error {
 		if run.Label != "" {
 			fmt.Printf("Label:         %s\n", run.Label)
 		}
-		if len(run.Tags) > 0 {
-			fmt.Printf("Tags:          %v\n", run.Tags)
-		}
 		fmt.Printf("Owner:         %s\n", run.RunOwner)
-		fmt.Printf("Created:       %s\n", run.CreatedAt.Format(time.RFC3339))
-		if !run.StartedAt.IsZero() {
-			fmt.Printf("Started:       %s\n", run.StartedAt.Format(time.RFC3339))
+		if !run.StartTime.IsZero() {
+			fmt.Printf("Started:       %s\n", run.StartTime.Format(time.RFC3339))
 		}
-		if !run.CompletedAt.IsZero() {
-			fmt.Printf("Completed:     %s\n", run.CompletedAt.Format(time.RFC3339))
-		}
-
-		// Display input
-		if run.Input != nil {
-			fmt.Printf("\nInput:\n")
-			inputJSON, _ := json.MarshalIndent(run.Input, "  ", "  ")
-			fmt.Printf("%s\n", string(inputJSON))
+		if !run.EndTime.IsZero() {
+			fmt.Printf("Completed:     %s\n", run.EndTime.Format(time.RFC3339))
 		}
 
-		// Display output
-		if run.Output != nil {
-			fmt.Printf("\nOutput:\n")
-			outputJSON, _ := json.MarshalIndent(run.Output, "  ", "  ")
-			fmt.Printf("%s\n", string(outputJSON))
+		// Display details
+		if run.Details != nil {
+			fmt.Printf("\nDetails:\n")
+			detailsJSON, _ := json.MarshalIndent(run.Details, "  ", "  ")
+			fmt.Printf("%s\n", string(detailsJSON))
 		}
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"RunID", "FlowID", "Status", "Label", "RunOwner", "CreatedAt", "StartedAt", "CompletedAt"}
+		headers := []string{"RunID", "FlowID", "FlowTitle", "Status", "Label", "RunOwner", "StartTime", "EndTime"}
 		if err := formatter.FormatOutput(run, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/flows/run_show_definition.go
+++ b/cmd/flows/run_show_definition.go
@@ -8,12 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // RunShowDefinitionCmd represents the flows run show-definition command
@@ -35,44 +30,18 @@ Examples:
 func runFlowsRunShowDefinition(cmd *cobra.Command, args []string) error {
 	runID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Get run to find the flow ID
-	run, err := flowsClient.GetRun(ctx, runID)
+	run, err := flowsClient.GetRun(ctx, runID, nil)
 	if err != nil {
 		return fmt.Errorf("error getting run: %w", err)
 	}

--- a/cmd/flows/run_show_logs.go
+++ b/cmd/flows/run_show_logs.go
@@ -9,11 +9,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/flows"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -53,44 +50,20 @@ func init() {
 func runFlowsRunShowLogs(cmd *cobra.Command, args []string) error {
 	runID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Get run logs
-	logs, err := flowsClient.GetRunLogs(ctx, runID, runShowLogsLimit, runShowLogsOffset)
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get run logs. v4 uses marker pagination; offset is no longer accepted.
+	logs, err := flowsClient.GetRunLogs(ctx, runID, &flows.ListRunLogsOptions{
+		Limit: runShowLogsLimit,
+	})
 	if err != nil {
 		return fmt.Errorf("error getting run logs: %w", err)
 	}

--- a/cmd/flows/run_update.go
+++ b/cmd/flows/run_update.go
@@ -8,12 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/flows"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -54,7 +50,7 @@ func runFlowsRunUpdate(cmd *cobra.Command, args []string) error {
 	runID := args[0]
 
 	// Build update request with only specified fields
-	request := &flows.RunUpdateRequest{}
+	request := &flows.RunUpdate{}
 
 	if cmd.Flags().Changed("label") {
 		request.Label = runUpdateLabel
@@ -69,41 +65,15 @@ func runFlowsRunUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("at least one of --label or --tags must be specified")
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Update run
 	run, err := flowsClient.UpdateRun(ctx, runID, request)
@@ -116,9 +86,6 @@ func runFlowsRunUpdate(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "Run ID:    %s\n", run.RunID)
 	if run.Label != "" {
 		fmt.Fprintf(os.Stdout, "Label:     %s\n", run.Label)
-	}
-	if len(run.Tags) > 0 {
-		fmt.Fprintf(os.Stdout, "Tags:      %v\n", run.Tags)
 	}
 
 	return nil

--- a/cmd/flows/show.go
+++ b/cmd/flows/show.go
@@ -9,11 +9,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -39,41 +35,15 @@ Examples:
 func runFlowsShow(cmd *cobra.Command, args []string) error {
 	flowID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get flow
 	flow, err := flowsClient.GetFlow(ctx, flowID)
@@ -94,16 +64,9 @@ func runFlowsShow(cmd *cobra.Command, args []string) error {
 		if flow.Description != "" {
 			fmt.Printf("Description:   %s\n", flow.Description)
 		}
-		fmt.Printf("Owner:         %s\n", flow.FlowOwner)
-		fmt.Printf("Public:        %t\n", flow.Public)
-		fmt.Printf("Managed:       %t\n", flow.Managed)
-		fmt.Printf("Run Count:     %d\n", flow.RunCount)
-		fmt.Printf("Created:       %s\n", flow.CreatedAt.Format(time.RFC3339))
-		fmt.Printf("Updated:       %s\n", flow.UpdatedAt.Format(time.RFC3339))
-
-		if len(flow.Keywords) > 0 {
-			fmt.Printf("Keywords:      %v\n", flow.Keywords)
-		}
+		fmt.Printf("Owner:         %s\n", flow.OwnerID)
+		fmt.Printf("Created:       %s\n", flow.Created.Format(time.RFC3339))
+		fmt.Printf("Updated:       %s\n", flow.Updated.Format(time.RFC3339))
 
 		// Display definition
 		if flow.Definition != nil {
@@ -121,7 +84,7 @@ func runFlowsShow(cmd *cobra.Command, args []string) error {
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"ID", "Title", "Description", "FlowOwner", "Public", "Managed", "RunCount", "CreatedAt", "UpdatedAt"}
+		headers := []string{"ID", "Title", "Description", "OwnerID", "Created", "Updated"}
 		if err := formatter.FormatOutput(flow, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/flows/start.go
+++ b/cmd/flows/start.go
@@ -9,12 +9,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/flows"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -90,38 +86,6 @@ func runFlowsStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to parse input JSON: %w", err)
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
-
 	// Create context with timeout
 	var ctx context.Context
 	var cancel context.CancelFunc
@@ -133,16 +97,22 @@ func runFlowsStart(cmd *cobra.Command, args []string) error {
 	}
 	defer cancel()
 
-	// Build run request
-	request := &flows.RunRequest{
-		FlowID: flowID,
-		Body:   input,
-		Label:  startLabel,
-		Tags:   startTags,
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
 	}
 
-	// Start the flow
-	run, err := flowsClient.RunFlow(ctx, request)
+	// Build run input. In v4 the flow ID is passed to RunFlow directly and the
+	// first-state input goes under Body.
+	runInput := &flows.FlowInput{
+		Body:  input,
+		Label: startLabel,
+		Tags:  startTags,
+	}
+
+	// Start the flow (v4 RunFlow replaces the v3 RunFlow(request) form).
+	run, err := flowsClient.RunFlow(ctx, flowID, runInput)
 	if err != nil {
 		return fmt.Errorf("error starting flow: %w", err)
 	}
@@ -152,7 +122,7 @@ func runFlowsStart(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "Run ID:    %s\n", run.RunID)
 	fmt.Fprintf(os.Stdout, "Flow ID:   %s\n", run.FlowID)
 	fmt.Fprintf(os.Stdout, "Status:    %s\n", run.Status)
-	fmt.Fprintf(os.Stdout, "Created:   %s\n", run.CreatedAt.Format(time.RFC3339))
+	fmt.Fprintf(os.Stdout, "Started:   %s\n", run.StartTime.Format(time.RFC3339))
 
 	// Wait for completion if requested
 	if startWait {
@@ -165,15 +135,15 @@ func runFlowsStart(cmd *cobra.Command, args []string) error {
 
 		fmt.Fprintf(os.Stdout, "\nFlow completed!\n")
 		fmt.Fprintf(os.Stdout, "Final Status:  %s\n", finalRun.Status)
-		if !finalRun.CompletedAt.IsZero() {
-			fmt.Fprintf(os.Stdout, "Completed At:  %s\n", finalRun.CompletedAt.Format(time.RFC3339))
+		if !finalRun.EndTime.IsZero() {
+			fmt.Fprintf(os.Stdout, "Completed At:  %s\n", finalRun.EndTime.Format(time.RFC3339))
 		}
 
-		// Display output if available
-		if finalRun.Output != nil {
-			fmt.Fprintf(os.Stdout, "\nOutput:\n")
-			outputJSON, _ := json.MarshalIndent(finalRun.Output, "  ", "  ")
-			fmt.Fprintf(os.Stdout, "%s\n", string(outputJSON))
+		// Display details if available
+		if finalRun.Details != nil {
+			fmt.Fprintf(os.Stdout, "\nDetails:\n")
+			detailsJSON, _ := json.MarshalIndent(finalRun.Details, "  ", "  ")
+			fmt.Fprintf(os.Stdout, "%s\n", string(detailsJSON))
 		}
 	} else {
 		fmt.Fprintf(os.Stdout, "\nMonitor run status with: globus flows run show %s\n", run.RunID)

--- a/cmd/flows/update.go
+++ b/cmd/flows/update.go
@@ -9,12 +9,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/flows"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/flows"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -23,7 +19,6 @@ var (
 	updateDefinitionFile string
 	updateSchemaFile     string
 	updateKeywords       []string
-	updatePublic         *bool
 
 	// Authentication policy flags (Python SDK v4.1.0)
 	updateHighAssurance   bool
@@ -66,10 +61,10 @@ func init() {
 	UpdateCmd.Flags().StringVar(&updateSchemaFile, "schema-file", "", "Path to input schema JSON file")
 	UpdateCmd.Flags().StringSliceVar(&updateKeywords, "keywords", []string{}, "Comma-separated keywords")
 
-	// Use a pointer so we can detect if flag was set
+	// Retained for CLI-surface compatibility; the v4 FlowUpdate model does not
+	// carry a visibility field, so this flag is currently a no-op.
 	var publicFlag bool
-	UpdateCmd.Flags().BoolVar(&publicFlag, "public", false, "Make flow publicly visible")
-	updatePublic = &publicFlag
+	UpdateCmd.Flags().BoolVar(&publicFlag, "public", false, "Make flow publicly visible (currently a no-op)")
 
 	// Authentication policy flags (Python SDK v4.1.0)
 	UpdateCmd.Flags().BoolVar(&updateHighAssurance, "high-assurance", false, "Require high-assurance authentication for flow runs")
@@ -81,7 +76,7 @@ func runFlowsUpdate(cmd *cobra.Command, args []string) error {
 	flowID := args[0]
 
 	// Build update request with only specified fields
-	request := &flows.FlowUpdateRequest{}
+	request := &flows.FlowUpdate{}
 
 	if updateTitle != "" {
 		request.Title = updateTitle
@@ -121,60 +116,18 @@ func runFlowsUpdate(cmd *cobra.Command, args []string) error {
 		request.Keywords = updateKeywords
 	}
 
-	if cmd.Flags().Changed("public") {
-		request.Public = updatePublic
-	}
-
-	// Apply authentication policy if any policy flag was changed
-	if cmd.Flags().Changed("high-assurance") || cmd.Flags().Changed("required-mfa") || cmd.Flags().Changed("session-policies") {
-		policy := &flows.FlowAuthenticationPolicy{}
-		if cmd.Flags().Changed("high-assurance") {
-			policy.HighAssurance = &updateHighAssurance
-		}
-		if cmd.Flags().Changed("required-mfa") {
-			policy.RequiredMFA = &updateRequiredMFA
-		}
-		if cmd.Flags().Changed("session-policies") {
-			policy.SessionPolicies = updateSessionPolicies
-		}
-		request.AuthenticationPolicy = policy
-	}
-
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create flows client
-	flowsClient, err := flows.NewClient(
-		flows.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create flows client: %w", err)
-	}
+	// Note: the v4 FlowUpdate model does not carry the --public visibility flag
+	// or the authentication-policy flags, so those flags are currently no-ops.
 
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Flows client authorized for the current profile.
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Update flow
 	flow, err := flowsClient.UpdateFlow(ctx, flowID, request)
@@ -186,7 +139,7 @@ func runFlowsUpdate(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "Flow updated successfully!\n\n")
 	fmt.Fprintf(os.Stdout, "Flow ID:   %s\n", flow.ID)
 	fmt.Fprintf(os.Stdout, "Title:     %s\n", flow.Title)
-	fmt.Fprintf(os.Stdout, "Updated:   %s\n", flow.UpdatedAt.Format(time.RFC3339))
+	fmt.Fprintf(os.Stdout, "Updated:   %s\n", flow.Updated.Format(time.RFC3339))
 
 	return nil
 }

--- a/cmd/group/client.go
+++ b/cmd/group/client.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package group
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
+)
+
+// getClient builds a v4 Groups client authorized for the current profile from
+// the per-resource-server GlobusApp token store. It replaces the previous
+// per-command recipe of loading the legacy token file and wrapping a static
+// authorizer. On a missing/expired token it returns an error advising login.
+func getClient(ctx context.Context) (*groups.Client, error) {
+	profile := viper.GetString("profile")
+
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	cfg, err := globusauth.ClientConfig(ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret, globusauth.ServiceGroups)
+	if err != nil {
+		return nil, fmt.Errorf("not logged in: %w", err)
+	}
+
+	client, err := groups.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create groups client: %w", err)
+	}
+	return client, nil
+}

--- a/cmd/group/create.go
+++ b/cmd/group/create.go
@@ -8,12 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/groups"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -51,41 +47,15 @@ func init() {
 }
 
 func runCreateGroup(cmd *cobra.Command, args []string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create groups client
-	groupsClient, err := groups.NewClient(
-		groups.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create groups client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Prepare group creation request
 	newGroup := &groups.GroupCreate{

--- a/cmd/group/delete.go
+++ b/cmd/group/delete.go
@@ -8,12 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/groups"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var deleteConfirm bool
@@ -61,41 +56,15 @@ func runDeleteGroup(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create groups client
-	groupsClient, err := groups.NewClient(
-		groups.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create groups client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Delete the group
 	err = groupsClient.DeleteGroup(ctx, groupID)

--- a/cmd/group/list.go
+++ b/cmd/group/list.go
@@ -8,11 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/groups"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -54,43 +50,15 @@ func init() {
 }
 
 func runListGroups(cmd *cobra.Command, args []string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create groups client
-	groupsClient, err := groups.NewClient(
-		groups.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create groups client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// The Globus Groups API only lists the caller's own groups
 	// (GET /groups/my_groups); optional status filtering is passed through.
@@ -104,7 +72,7 @@ func runListGroups(cmd *cobra.Command, args []string) error {
 
 	if format == "text" {
 		// Text output - human readable table
-		if len(groupList.Groups) == 0 {
+		if len(groupList) == 0 {
 			fmt.Println("No groups found.")
 			return nil
 		}
@@ -116,7 +84,7 @@ func runListGroups(cmd *cobra.Command, args []string) error {
 			"--------",
 			"--------")
 
-		for _, group := range groupList.Groups {
+		for _, group := range groupList {
 			name := group.Name
 			if len(name) > 40 {
 				name = name[:37] + "..."
@@ -134,12 +102,12 @@ func runListGroups(cmd *cobra.Command, args []string) error {
 				admin)
 		}
 
-		fmt.Printf("\nTotal: %d group(s)\n", len(groupList.Groups))
+		fmt.Printf("\nTotal: %d group(s)\n", len(groupList))
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
 		headers := []string{"ID", "Name", "Description", "MemberCount", "IsGroupAdmin", "IsMember"}
-		if err := formatter.FormatOutput(groupList.Groups, headers); err != nil {
+		if err := formatter.FormatOutput(groupList, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}
 	}

--- a/cmd/group/member_add.go
+++ b/cmd/group/member_add.go
@@ -8,12 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/groups"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var memberAddRole string
@@ -50,41 +46,15 @@ func runMemberAdd(cmd *cobra.Command, args []string) error {
 	groupID := args[0]
 	identityID := args[1]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create groups client
-	groupsClient, err := groups.NewClient(
-		groups.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create groups client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Add member to group via a single batch membership action
 	// (POST /groups/{id}); the API has no dedicated add-member route.

--- a/cmd/group/member_list.go
+++ b/cmd/group/member_list.go
@@ -8,11 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/groups"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -41,41 +38,15 @@ Output Formats:
 func runMemberList(cmd *cobra.Command, args []string) error {
 	groupID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create groups client
-	groupsClient, err := groups.NewClient(
-		groups.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create groups client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Members are returned by fetching the group with the memberships
 	// representation (the API has no standalone list-members route).

--- a/cmd/group/member_remove.go
+++ b/cmd/group/member_remove.go
@@ -8,12 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/groups"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // MemberRemoveCmd represents the member remove command
@@ -35,41 +31,15 @@ func runMemberRemove(cmd *cobra.Command, args []string) error {
 	groupID := args[0]
 	identityID := args[1]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create groups client
-	groupsClient, err := groups.NewClient(
-		groups.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create groups client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Remove member from group via a single batch membership action
 	// (POST /groups/{id}); the API has no dedicated remove-member route.

--- a/cmd/group/show.go
+++ b/cmd/group/show.go
@@ -8,11 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/groups"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -44,41 +40,15 @@ Output Formats:
 func runShowGroup(cmd *cobra.Command, args []string) error {
 	groupID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create groups client
-	groupsClient, err := groups.NewClient(
-		groups.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create groups client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get group details (include memberships/policies via GetGroupOptions;
 	// nil requests the default representation).

--- a/cmd/group/update.go
+++ b/cmd/group/update.go
@@ -8,12 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/groups"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -55,41 +51,15 @@ func runUpdateGroup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("at least one of --name or --description must be provided")
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create groups client
-	groupsClient, err := groups.NewClient(
-		groups.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create groups client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Prepare update request
 	update := &groups.GroupUpdate{}

--- a/cmd/search/client.go
+++ b/cmd/search/client.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package search
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/search"
+)
+
+// getClient builds a v4 Search client authorized for the current profile from
+// the per-resource-server GlobusApp token store. It replaces the previous
+// per-command recipe of loading the legacy token file and wrapping a static
+// authorizer. On a missing/expired token it returns an error advising login.
+func getClient(ctx context.Context) (*search.Client, error) {
+	profile := viper.GetString("profile")
+
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	cfg, err := globusauth.ClientConfig(ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret, globusauth.ServiceSearch)
+	if err != nil {
+		return nil, fmt.Errorf("not logged in: %w", err)
+	}
+
+	client, err := search.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create search client: %w", err)
+	}
+	return client, nil
+}

--- a/cmd/search/index_create.go
+++ b/cmd/search/index_create.go
@@ -8,12 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/search"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -56,47 +52,21 @@ func init() {
 }
 
 func runIndexCreate(cmd *cobra.Command, args []string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Build create request
-	createRequest := &search.IndexCreateRequest{
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Build create request. Upstream create_index accepts only display_name and
+	// description; the --monitored flag is retained but has no effect.
+	createRequest := &search.IndexCreate{
 		DisplayName: indexCreateDisplayName,
 		Description: indexCreateDescription,
-		IsMonitored: indexCreateMonitored,
 	}
 
 	// Create index
@@ -112,9 +82,10 @@ func runIndexCreate(cmd *cobra.Command, args []string) error {
 	if index.Description != "" {
 		fmt.Fprintf(os.Stdout, "Description:  %s\n", index.Description)
 	}
-	fmt.Fprintf(os.Stdout, "Active:       %t\n", index.IsActive)
-	fmt.Fprintf(os.Stdout, "Created By:   %s\n", index.CreatedBy)
-	fmt.Fprintf(os.Stdout, "Created At:   %s\n", index.CreatedAt.Format(time.RFC3339))
+	fmt.Fprintf(os.Stdout, "Status:       %s\n", index.Status)
+	if !index.Created.IsZero() {
+		fmt.Fprintf(os.Stdout, "Created At:   %s\n", index.Created.Format(time.RFC3339))
+	}
 
 	return nil
 }

--- a/cmd/search/index_delete.go
+++ b/cmd/search/index_delete.go
@@ -10,12 +10,7 @@ import (
 	"strings"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var indexDeleteConfirm bool
@@ -45,41 +40,15 @@ func init() {
 func runIndexDelete(cmd *cobra.Command, args []string) error {
 	indexID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get index first to display name and confirm
 	index, err := searchClient.GetIndex(ctx, indexID)

--- a/cmd/search/index_list.go
+++ b/cmd/search/index_list.go
@@ -8,11 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -52,46 +48,20 @@ func init() {
 }
 
 func runIndexList(cmd *cobra.Command, args []string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// List indices. The Search index_list endpoint is NOT paginated — sending
 	// limit/offset returns HTTP 400 — so no options are passed. The --limit and
 	// --offset flags are retained as deprecated no-ops for compatibility.
-	indexList, err := searchClient.ListIndexes(ctx, nil)
+	indexList, err := searchClient.IndexList(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("error listing indices: %w", err)
 	}
@@ -106,11 +76,11 @@ func runIndexList(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		fmt.Printf("%-36s  %-40s  %-10s  %-10s\n", "Index ID", "Display Name", "Active", "Public")
+		fmt.Printf("%-36s  %-40s  %-12s  %-10s\n", "Index ID", "Display Name", "Status", "Entries")
 		fmt.Printf("%s  %s  %s  %s\n",
 			"------------------------------------",
 			"----------------------------------------",
-			"----------",
+			"------------",
 			"----------")
 
 		for _, index := range indexList.Indexes {
@@ -119,28 +89,18 @@ func runIndexList(cmd *cobra.Command, args []string) error {
 				displayName = displayName[:37] + "..."
 			}
 
-			active := "No"
-			if index.IsActive {
-				active = "Yes"
-			}
-
-			public := "No"
-			if index.IsPublic {
-				public = "Yes"
-			}
-
-			fmt.Printf("%-36s  %-40s  %-10s  %-10s\n",
+			fmt.Printf("%-36s  %-40s  %-12s  %-10d\n",
 				index.ID,
 				displayName,
-				active,
-				public)
+				index.Status,
+				index.NumEntries)
 		}
 
 		fmt.Printf("\nTotal: %d index(es)\n", len(indexList.Indexes))
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"ID", "DisplayName", "Description", "IsActive", "IsPublic", "CreatedBy"}
+		headers := []string{"ID", "DisplayName", "Description", "Status", "NumEntries", "NumSubjects"}
 		if err := formatter.FormatOutput(indexList.Indexes, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/search/index_reopen.go
+++ b/cmd/search/index_reopen.go
@@ -8,12 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // IndexReopenCmd represents the search index reopen command.
@@ -35,41 +30,15 @@ Examples:
 func runIndexReopen(cmd *cobra.Command, args []string) error {
 	indexID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Reopen the index
 	index, err := searchClient.ReopenIndex(ctx, indexID)
@@ -81,7 +50,7 @@ func runIndexReopen(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "Index reopened successfully!\n\n")
 	fmt.Fprintf(os.Stdout, "Index ID:     %s\n", index.ID)
 	fmt.Fprintf(os.Stdout, "Display Name: %s\n", index.DisplayName)
-	fmt.Fprintf(os.Stdout, "Is Active:    %t\n", index.IsActive)
+	fmt.Fprintf(os.Stdout, "Status:       %s\n", index.Status)
 
 	return nil
 }

--- a/cmd/search/index_show.go
+++ b/cmd/search/index_show.go
@@ -8,11 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -38,41 +34,15 @@ Examples:
 func runIndexShow(cmd *cobra.Command, args []string) error {
 	indexID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get index details
 	index, err := searchClient.GetIndex(ctx, indexID)
@@ -92,23 +62,29 @@ func runIndexShow(cmd *cobra.Command, args []string) error {
 		if index.Description != "" {
 			fmt.Printf("Description:  %s\n", index.Description)
 		}
-		fmt.Printf("Active:       %t\n", index.IsActive)
-		fmt.Printf("Public:       %t\n", index.IsPublic)
-		fmt.Printf("Monitored:    %t\n", index.IsMonitored)
-		if index.MonitoringFrequency > 0 {
-			fmt.Printf("Monitoring Frequency: %d minutes\n", index.MonitoringFrequency)
+		fmt.Printf("Status:       %s\n", index.Status)
+		fmt.Printf("Entries:      %d\n", index.NumEntries)
+		fmt.Printf("Subjects:     %d\n", index.NumSubjects)
+		fmt.Printf("Size:         %.2f MB\n", index.SizeInMB)
+		if index.MaxSizeInMB > 0 {
+			fmt.Printf("Max Size:     %d MB\n", index.MaxSizeInMB)
 		}
-		fmt.Printf("Max Size:     %d MB\n", index.MaxSize)
+		if index.SubscriptionID != "" {
+			fmt.Printf("Subscription: %s\n", index.SubscriptionID)
+		}
 
 		fmt.Printf("\nMetadata\n")
 		fmt.Printf("--------\n")
-		fmt.Printf("Created By:   %s\n", index.CreatedBy)
-		fmt.Printf("Created At:   %s\n", index.CreatedAt.Format(time.RFC3339))
-		fmt.Printf("Updated At:   %s\n", index.UpdatedAt.Format(time.RFC3339))
+		if !index.Created.IsZero() {
+			fmt.Printf("Created At:   %s\n", index.Created.Format(time.RFC3339))
+		}
+		if !index.LastModified.IsZero() {
+			fmt.Printf("Updated At:   %s\n", index.LastModified.Format(time.RFC3339))
+		}
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"ID", "DisplayName", "Description", "IsActive", "IsPublic", "CreatedBy"}
+		headers := []string{"ID", "DisplayName", "Description", "Status", "NumEntries", "NumSubjects"}
 		if err := formatter.FormatOutput(index, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/search/index_update.go
+++ b/cmd/search/index_update.go
@@ -8,12 +8,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/search"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -66,56 +62,26 @@ func runIndexUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("at least one update flag must be provided")
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Build update request
-	updateRequest := &search.IndexUpdateRequest{}
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Build update request. Upstream update_index accepts only display_name and
+	// description; the --active and --monitored flags are retained but have no
+	// effect.
+	updateRequest := &search.IndexUpdate{}
 
 	if cmd.Flags().Changed("display-name") {
 		updateRequest.DisplayName = indexUpdateDisplayName
 	}
 	if cmd.Flags().Changed("description") {
 		updateRequest.Description = indexUpdateDescription
-	}
-	if cmd.Flags().Changed("active") {
-		updateRequest.IsActive = indexUpdateActive
-	}
-	if cmd.Flags().Changed("monitored") {
-		updateRequest.IsMonitored = indexUpdateMonitored
 	}
 
 	// Update index
@@ -131,9 +97,10 @@ func runIndexUpdate(cmd *cobra.Command, args []string) error {
 	if index.Description != "" {
 		fmt.Fprintf(os.Stdout, "Description:  %s\n", index.Description)
 	}
-	fmt.Fprintf(os.Stdout, "Active:       %t\n", index.IsActive)
-	fmt.Fprintf(os.Stdout, "Monitored:    %t\n", index.IsMonitored)
-	fmt.Fprintf(os.Stdout, "Updated At:   %s\n", index.UpdatedAt.Format(time.RFC3339))
+	fmt.Fprintf(os.Stdout, "Status:       %s\n", index.Status)
+	if !index.LastModified.IsZero() {
+		fmt.Fprintf(os.Stdout, "Updated At:   %s\n", index.LastModified.Format(time.RFC3339))
+	}
 
 	return nil
 }

--- a/cmd/search/ingest.go
+++ b/cmd/search/ingest.go
@@ -9,12 +9,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/search"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -90,77 +86,50 @@ func runSearchIngest(cmd *cobra.Command, args []string) error {
 		documentsJSON = []byte(ingestData)
 	}
 
-	// Parse documents
-	var documents []search.SearchDocument
+	// Parse documents into GMeta entry documents.
+	var documents []search.GMetaEntryDocument
 	if err := json.Unmarshal(documentsJSON, &documents); err != nil {
 		// Try parsing as a single document
-		var singleDoc search.SearchDocument
+		var singleDoc search.GMetaEntryDocument
 		if err2 := json.Unmarshal(documentsJSON, &singleDoc); err2 != nil {
 			return fmt.Errorf("failed to parse documents (tried both array and single document): %w / %w", err, err2)
 		}
-		documents = []search.SearchDocument{singleDoc}
+		documents = []search.GMetaEntryDocument{singleDoc}
 	}
 
 	if len(documents) == 0 {
 		return fmt.Errorf("no documents found in input")
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Build ingest request
-	ingestRequest := &search.IngestRequest{
-		IndexID:   indexID,
-		Documents: documents,
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
 	}
 
+	// Build a GMetaList ingest document ({ingest_type:"GMetaList", ingest_data})
+	// and submit it. v4 wraps documents in the upstream ingest envelope.
+	ingestDoc := search.NewGMetaListIngest(documents)
+
 	// Execute ingest
-	response, err := searchClient.IngestDocuments(ctx, ingestRequest)
+	response, err := searchClient.Ingest(ctx, indexID, ingestDoc)
 	if err != nil {
 		return fmt.Errorf("error ingesting documents: %w", err)
 	}
 
 	// Display success message
 	fmt.Fprintf(os.Stdout, "Documents ingested successfully!\n\n")
-	fmt.Fprintf(os.Stdout, "Task ID:      %s\n", response.Task.TaskID)
-	fmt.Fprintf(os.Stdout, "Total:        %d documents\n", response.Total)
-	fmt.Fprintf(os.Stdout, "Succeeded:    %d documents\n", response.Succeeded)
-	fmt.Fprintf(os.Stdout, "Failed:       %d documents\n", response.Failed)
-	if response.Task.TaskID != "" {
-		fmt.Fprintf(os.Stdout, "\nCheck task status with: globus search task show %s\n", response.Task.TaskID)
+	fmt.Fprintf(os.Stdout, "Task ID:      %s\n", response.TaskID)
+	fmt.Fprintf(os.Stdout, "Total:        %d documents\n", len(documents))
+	if response.Message != "" {
+		fmt.Fprintf(os.Stdout, "Message:      %s\n", response.Message)
+	}
+	if response.TaskID != "" {
+		fmt.Fprintf(os.Stdout, "\nCheck task status with: globus search task show %s\n", response.TaskID)
 	}
 
 	return nil

--- a/cmd/search/query.go
+++ b/cmd/search/query.go
@@ -9,11 +9,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/search"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -63,47 +60,26 @@ func init() {
 func runSearchQuery(cmd *cobra.Command, args []string) error {
 	indexID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Execute a simple search. Upstream models this as GET
 	// /v1/index/{id}/search with q/offset/limit/advanced query params
-	// (GetSearch), not a POST body — the POST Search sends a malformed body and
+	// (SearchGet), not a POST body — the POST Search sends a malformed body and
 	// returns HTTP 400.
-	response, err := searchClient.GetSearch(ctx, indexID, queryString, queryOffset, queryLimit, queryAdvanced)
+	response, err := searchClient.SearchGet(ctx, indexID, &search.SearchGetOptions{
+		Q:        queryString,
+		Offset:   queryOffset,
+		Limit:    queryLimit,
+		Advanced: queryAdvanced,
+	})
 	if err != nil {
 		return fmt.Errorf("error executing search: %w", err)
 	}
@@ -113,44 +89,35 @@ func runSearchQuery(cmd *cobra.Command, args []string) error {
 
 	if format == "text" {
 		// Text output - human readable
-		if len(response.Results) == 0 {
+		if len(response.GMeta) == 0 {
 			fmt.Println("No results found.")
 			return nil
 		}
 
-		fmt.Printf("Search Results (showing %d of %d total)\n", len(response.Results), response.Total)
+		fmt.Printf("Search Results (showing %d of %d total)\n", len(response.GMeta), response.Total)
 		fmt.Printf("========================================\n\n")
 
-		for i, result := range response.Results {
+		for i, result := range response.GMeta {
 			fmt.Printf("Result %d:\n", i+1)
 			fmt.Printf("  Subject: %s\n", result.Subject)
-			fmt.Printf("  Score:   %.4f\n", result.Score)
 
 			// Display content
-			if result.Content != nil {
+			if len(result.Content) > 0 {
 				contentJSON, _ := json.MarshalIndent(result.Content, "    ", "  ")
 				fmt.Printf("  Content:\n    %s\n", string(contentJSON))
-			}
-
-			// Display highlights
-			if len(result.Highlight) > 0 {
-				fmt.Printf("  Highlights:\n")
-				for field, highlights := range result.Highlight {
-					fmt.Printf("    %s: %v\n", field, highlights)
-				}
 			}
 			fmt.Println()
 		}
 
-		if response.HasMore {
+		if response.HasNextPage {
 			nextOffset := queryOffset + queryLimit
 			fmt.Printf("More results available. Use --offset %d to see next page.\n", nextOffset)
 		}
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"Subject", "Content", "Score"}
-		if err := formatter.FormatOutput(response.Results, headers); err != nil {
+		headers := []string{"Subject", "Content", "Entries"}
+		if err := formatter.FormatOutput(response.GMeta, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}
 	}

--- a/cmd/search/subject_delete.go
+++ b/cmd/search/subject_delete.go
@@ -8,12 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // SubjectDeleteCmd represents the search subject delete command
@@ -39,50 +34,19 @@ func runSubjectDelete(cmd *cobra.Command, args []string) error {
 	indexID := args[0]
 	subject := args[1]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Build delete request
-	deleteRequest := &search.DeleteDocumentsRequest{
-		IndexID:  indexID,
-		Subjects: []string{subject},
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
 	}
 
-	// Execute delete
-	response, err := searchClient.DeleteDocuments(ctx, deleteRequest)
+	// Execute delete. v4 deletes a single subject via DELETE
+	// /index/{id}/subject?subject=...
+	response, err := searchClient.DeleteSubject(ctx, indexID, subject)
 	if err != nil {
 		return fmt.Errorf("error deleting subject: %w", err)
 	}

--- a/cmd/search/subject_show.go
+++ b/cmd/search/subject_show.go
@@ -9,11 +9,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -41,55 +37,26 @@ func runSubjectShow(cmd *cobra.Command, args []string) error {
 	indexID := args[0]
 	subject := args[1]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Search for the specific subject
-	searchRequest := &search.SearchRequest{
-		IndexID: indexID,
-		Query:   fmt.Sprintf("subject:%s", subject),
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
 	}
 
-	response, err := searchClient.Search(ctx, searchRequest)
+	// Fetch the subject directly. v4 exposes GET /index/{id}/subject?subject=...
+	// (GetSubject), which returns the visible entries for the subject — a
+	// cleaner match than the previous "subject:<id>" search query.
+	result, err := searchClient.GetSubject(ctx, indexID, subject)
 	if err != nil {
-		return fmt.Errorf("error searching for subject: %w", err)
+		return fmt.Errorf("error getting subject: %w", err)
 	}
 
 	// Check if subject was found
-	if len(response.Results) == 0 {
+	if len(result.Entries) == 0 && len(result.Content) == 0 {
 		return fmt.Errorf("subject '%s' not found or you don't have permission to view it", subject)
 	}
 
@@ -98,38 +65,32 @@ func runSubjectShow(cmd *cobra.Command, args []string) error {
 
 	if format == "text" {
 		// Text output - human readable
-		result := response.Results[0]
-
 		fmt.Printf("Subject: %s\n", result.Subject)
 		fmt.Printf("========================================\n\n")
 
-		// Display content
-		if result.Content != nil {
+		// Display entries and their content
+		if len(result.Entries) > 0 {
+			for i, entry := range result.Entries {
+				fmt.Printf("Entry %d", i+1)
+				if entry.EntryID != "" {
+					fmt.Printf(" (%s)", entry.EntryID)
+				}
+				fmt.Println(":")
+				if entry.Content != nil {
+					contentJSON, _ := json.MarshalIndent(entry.Content, "  ", "  ")
+					fmt.Printf("  %s\n\n", string(contentJSON))
+				}
+			}
+		} else if len(result.Content) > 0 {
 			fmt.Printf("Content:\n")
 			contentJSON, _ := json.MarshalIndent(result.Content, "  ", "  ")
 			fmt.Printf("  %s\n\n", string(contentJSON))
 		}
-
-		// Display score
-		if result.Score > 0 {
-			fmt.Printf("Relevance Score: %.4f\n", result.Score)
-		}
-
-		// Display highlights if any
-		if len(result.Highlight) > 0 {
-			fmt.Printf("\nHighlights:\n")
-			for field, highlights := range result.Highlight {
-				fmt.Printf("  %s:\n", field)
-				for _, hl := range highlights {
-					fmt.Printf("    - %s\n", hl)
-				}
-			}
-		}
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"Subject", "Content", "Score"}
-		if err := formatter.FormatOutput(response.Results[0], headers); err != nil {
+		headers := []string{"Subject", "Entries", "Content"}
+		if err := formatter.FormatOutput(result, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}
 	}

--- a/cmd/search/task_show.go
+++ b/cmd/search/task_show.go
@@ -8,11 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/search"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -39,44 +35,18 @@ Examples:
 func runTaskShow(cmd *cobra.Command, args []string) error {
 	taskID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create search client
-	searchClient, err := search.NewClient(
-		search.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create search client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Get task status
-	taskStatus, err := searchClient.GetTaskStatus(ctx, taskID)
+	// Build a v4 Search client authorized for the current profile.
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get task status. v4 GetTask returns the task envelope directly.
+	taskStatus, err := searchClient.GetTask(ctx, taskID)
 	if err != nil {
 		return fmt.Errorf("error getting task status: %w", err)
 	}
@@ -91,23 +61,19 @@ func runTaskShow(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Task ID:    %s\n", taskStatus.TaskID)
 		fmt.Printf("Index ID:   %s\n", taskStatus.IndexID)
 		fmt.Printf("State:      %s\n", taskStatus.State)
-		if taskStatus.CreatedAt != "" {
-			fmt.Printf("Created At: %s\n", taskStatus.CreatedAt)
+		if !taskStatus.Created.IsZero() {
+			fmt.Printf("Created At: %s\n", taskStatus.Created.Format(time.RFC3339))
 		}
-		if taskStatus.CompletedAt != "" {
-			fmt.Printf("Completed:  %s\n", taskStatus.CompletedAt)
+		if !taskStatus.Completed.IsZero() {
+			fmt.Printf("Completed:  %s\n", taskStatus.Completed.Format(time.RFC3339))
 		}
 		if taskStatus.Message != "" {
 			fmt.Printf("Message:    %s\n", taskStatus.Message)
 		}
-
-		if taskStatus.DetailLocation != "" {
-			fmt.Printf("\nDetails: %s\n", taskStatus.DetailLocation)
-		}
 	} else {
 		// JSON or CSV output
 		formatter := output.NewFormatter(format, os.Stdout)
-		headers := []string{"TaskID", "IndexID", "State", "CreatedAt", "CompletedAt", "Message"}
+		headers := []string{"TaskID", "IndexID", "State", "Created", "Completed", "Message"}
 		if err := formatter.FormatOutput(taskStatus, headers); err != nil {
 			return fmt.Errorf("error formatting output: %w", err)
 		}

--- a/cmd/timer/client.go
+++ b/cmd/timer/client.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package timer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/timers"
+)
+
+// getClient builds a v4 Timers client authorized for the current profile from
+// the per-resource-server GlobusApp token store. It replaces the previous
+// per-command recipe of loading the legacy token file and wrapping a static
+// authorizer. On a missing/expired token it returns an error advising login.
+func getClient(ctx context.Context) (*timers.Client, error) {
+	profile := viper.GetString("profile")
+
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	cfg, err := globusauth.ClientConfig(ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret, globusauth.ServiceTimers)
+	if err != nil {
+		return nil, fmt.Errorf("not logged in: %w", err)
+	}
+
+	client, err := timers.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create timers client: %w", err)
+	}
+	return client, nil
+}

--- a/cmd/timer/create_flow.go
+++ b/cmd/timer/create_flow.go
@@ -9,12 +9,8 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/timers"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/timers"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -129,41 +125,15 @@ func runCreateFlowTimer(cmd *cobra.Command, args []string) error {
 		stopTime = &st
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create timers client
-	timersClient, err := timers.NewClient(
-		timers.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create timers client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Timers client authorized for the current profile.
+	timersClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Cron scheduling does not exist in the Globus Timers API at this SDK
 	// version; only once and recurring (fixed interval) schedules are supported.

--- a/cmd/timer/delete.go
+++ b/cmd/timer/delete.go
@@ -10,12 +10,7 @@ import (
 	"strings"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/timers"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var deleteConfirm bool
@@ -46,41 +41,15 @@ func init() {
 func runDeleteTimer(cmd *cobra.Command, args []string) error {
 	timerID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create timers client
-	timersClient, err := timers.NewClient(
-		timers.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create timers client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Timers client authorized for the current profile.
+	timersClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get timer first to display name and confirm
 	timer, err := timersClient.GetTimer(ctx, timerID)

--- a/cmd/timer/list.go
+++ b/cmd/timer/list.go
@@ -8,11 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/timers"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -40,41 +36,15 @@ Output Formats:
 }
 
 func runListTimers(cmd *cobra.Command, args []string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create timers client
-	timersClient, err := timers.NewClient(
-		timers.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create timers client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Timers client authorized for the current profile.
+	timersClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// List timers
 	timerList, err := timersClient.ListTimers(ctx, nil)

--- a/cmd/timer/pause.go
+++ b/cmd/timer/pause.go
@@ -8,12 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/timers"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // PauseCmd represents the timer pause command
@@ -38,41 +33,15 @@ Examples:
 func runPauseTimer(cmd *cobra.Command, args []string) error {
 	timerID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create timers client
-	timersClient, err := timers.NewClient(
-		timers.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create timers client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Timers client authorized for the current profile.
+	timersClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get timer first to display name
 	timer, err := timersClient.GetTimer(ctx, timerID)

--- a/cmd/timer/resume.go
+++ b/cmd/timer/resume.go
@@ -8,12 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/timers"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // ResumeCmd represents the timer resume command
@@ -37,41 +32,15 @@ Examples:
 func runResumeTimer(cmd *cobra.Command, args []string) error {
 	timerID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create timers client
-	timersClient, err := timers.NewClient(
-		timers.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create timers client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Timers client authorized for the current profile.
+	timersClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get timer first to display name
 	timer, err := timersClient.GetTimer(ctx, timerID)

--- a/cmd/timer/show.go
+++ b/cmd/timer/show.go
@@ -8,11 +8,7 @@ import (
 	"os"
 	"time"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/timers"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -44,41 +40,15 @@ Output Formats:
 func runShowTimer(cmd *cobra.Command, args []string) error {
 	timerID := args[0]
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create authorizer
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create timers client
-	timersClient, err := timers.NewClient(
-		timers.WithAuthorizer(coreAuthorizer),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create timers client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Timers client authorized for the current profile.
+	timersClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get timer details
 	timer, err := timersClient.GetTimer(ctx, timerID)

--- a/cmd/transfer/client.go
+++ b/cmd/transfer/client.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
+)
+
+// getClient builds a v4 Transfer client authorized for the current profile from
+// the per-resource-server GlobusApp token store. It replaces the previous
+// per-command recipe of loading the legacy token file and wrapping a static
+// authorizer. On a missing/expired token it returns an error advising login.
+func getClient(ctx context.Context) (*transfer.Client, error) {
+	profile := viper.GetString("profile")
+
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	cfg, err := globusauth.ClientConfig(ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret, globusauth.ServiceTransfer)
+	if err != nil {
+		return nil, fmt.Errorf("not logged in: %w", err)
+	}
+
+	client, err := transfer.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transfer client: %w", err)
+	}
+	return client, nil
+}

--- a/cmd/transfer/cp.go
+++ b/cmd/transfer/cp.go
@@ -11,12 +11,8 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/transfer"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
 )
 
 var (
@@ -71,67 +67,23 @@ Examples:
 
 // transferFiles transfers files between endpoints
 func transferFiles(cmd *cobra.Command, sourceEndpointID, sourcePath, destEndpointID, destPath string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration - not used with direct client initialization in v0.9.17
-	// We still load it for future use cases
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer for v0.9.17
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for v0.9.17 compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create transfer client with v0.9.17 compatible options
-	transferOptions := []transfer.Option{
-		transfer.WithAuthorizer(coreAuthorizer),
-	}
-
-	transferClient, err := transfer.NewClient(transferOptions...)
-	if err != nil {
-		return fmt.Errorf("failed to create transfer client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Parse deadline if provided
-	var deadline *time.Time
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Parse deadline if provided (validated here; formatted for the request below).
+	var deadline string
 	if transferDeadline != "" {
-		parsedDeadline, err := time.Parse("2006-01-02", transferDeadline)
-		if err != nil {
+		if _, err := time.Parse("2006-01-02", transferDeadline); err != nil {
 			return fmt.Errorf("invalid deadline format, use YYYY-MM-DD: %w", err)
 		}
-		deadline = &parsedDeadline
-	}
-
-	// Create transfer options map
-	optionsMap := map[string]interface{}{
-		"recursive":       transferRecursive,
-		"sync_level":      transferSync,
-		"preserve_mtime":  transferPreserveTime,
-		"verify_checksum": transferVerify,
-	}
-
-	if deadline != nil {
-		optionsMap["deadline"] = deadline
+		deadline = transferDeadline
 	}
 
 	// Show transfer details and confirm if not in dry run mode
@@ -159,14 +111,36 @@ func transferFiles(cmd *cobra.Command, sourceEndpointID, sourcePath, destEndpoin
 	s.Suffix = " Submitting transfer task..."
 	s.Start()
 
+	// Build the v4 transfer request. A submission ID minted from the service is
+	// required for idempotent submission.
+	submissionID, err := transferClient.GetSubmissionID(ctx)
+	if err != nil {
+		s.Stop()
+		return fmt.Errorf("failed to get submission ID: %w", err)
+	}
+
+	request := &transfer.Transfer{
+		DATA_TYPE:           "transfer",
+		SubmissionID:        submissionID,
+		SourceEndpoint:      sourceEndpointID,
+		DestinationEndpoint: destEndpointID,
+		Label:               transferLabel,
+		SyncLevel:           transferSync,
+		VerifyChecksum:      transferVerify,
+		PreserveTimestamp:   transferPreserveTime,
+		Deadline:            deadline,
+		Items: []transfer.TransferItem{
+			{
+				DATA_TYPE:       "transfer_item",
+				SourcePath:      sourcePath,
+				DestinationPath: destPath,
+				Recursive:       transferRecursive,
+			},
+		},
+	}
+
 	// Submit the transfer
-	taskResponse, err := transferClient.SubmitTransfer(
-		ctx,
-		sourceEndpointID, sourcePath,
-		destEndpointID, destPath,
-		transferLabel,
-		optionsMap,
-	)
+	taskResponse, err := transferClient.SubmitTransfer(ctx, request)
 	s.Stop()
 
 	if err != nil {

--- a/cmd/transfer/endpoint.go
+++ b/cmd/transfer/endpoint.go
@@ -10,11 +10,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/transfer"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
 )
 
 // EndpointCmd returns the endpoint command
@@ -118,71 +115,39 @@ returning matches based on the provided search text.`,
 
 // listEndpoints lists Globus endpoints
 func listEndpoints(cmd *cobra.Command) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration - not used with direct client initialization in v0.9.17
-	// We still load it for future use cases
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer for v0.9.17
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for v0.9.17 compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create transfer client with v0.9.17 compatible options
-	transferOptions := []transfer.Option{
-		transfer.WithAuthorizer(coreAuthorizer),
-	}
-
-	transferClient, err := transfer.NewClient(transferOptions...)
-	if err != nil {
-		return fmt.Errorf("failed to create transfer client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Prepare options for listing endpoints
-	options := &transfer.ListEndpointsOptions{
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Prepare options for endpoint search.
+	options := &transfer.EndpointSearchOptions{
 		Limit: limit,
 	}
 
-	// Add filters based on flags - simplified for SDK v0.9.17
 	if filterOwner != "" {
 		options.FilterOwnerID = filterOwner
 	}
 
-	// Filter scope handling for SDK v0.9.17
+	// Filter scope handling.
 	if filterRecentlyUsed {
 		options.FilterScope = "recently-used"
 	} else if filterMyTasksOnly {
 		options.FilterScope = "in-use"
 	}
 
-	// Search text for full text search
+	// Search text for full text search.
 	if searchText != "" {
-		options.FilterFullText = searchText
+		options.FilterFulltext = searchText
 	}
 
 	// Get the endpoints
-	endpoints, err := transferClient.ListEndpoints(ctx, options)
+	endpoints, err := transferClient.EndpointSearch(ctx, options)
 	if err != nil {
 		return fmt.Errorf("failed to list endpoints: %w", err)
 	}
@@ -202,60 +167,29 @@ func listEndpoints(cmd *cobra.Command) error {
 		Name      string
 		Owner     string
 		Activated bool
-		Connected bool
+		Public    bool
 	}
 	rows := make([]endpointRow, 0, len(endpoints.Data))
 	for _, e := range endpoints.Data {
 		rows = append(rows, endpointRow{
-			ID: e.ID, Name: e.DisplayName, Owner: e.OwnerString,
-			Activated: e.Activated, Connected: e.GCPConnected,
+			ID: e.ID, Name: e.DisplayName, Owner: e.Owner,
+			Activated: e.Activated, Public: e.Public,
 		})
 	}
-	return formatter.FormatOutput(rows, []string{"ID", "Name", "Owner", "Activated", "Connected"})
+	return formatter.FormatOutput(rows, []string{"ID", "Name", "Owner", "Activated", "Public"})
 }
 
 // showEndpoint shows details for a specific endpoint
 func showEndpoint(cmd *cobra.Command, endpointID string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration - not used with direct client initialization in v0.9.17
-	// We still load it for future use cases
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer for v0.9.17
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for v0.9.17 compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create transfer client with v0.9.17 compatible options
-	transferOptions := []transfer.Option{
-		transfer.WithAuthorizer(coreAuthorizer),
-	}
-
-	transferClient, err := transfer.NewClient(transferOptions...)
-	if err != nil {
-		return fmt.Errorf("failed to create transfer client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get the endpoint
 	endpoint, err := transferClient.GetEndpoint(ctx, endpointID)
@@ -277,14 +211,10 @@ func showEndpoint(cmd *cobra.Command, endpointID string) error {
 		fmt.Println("Endpoint Details:")
 		fmt.Printf("  ID:             %s\n", endpoint.ID)
 		fmt.Printf("  Display Name:   %s\n", endpoint.DisplayName)
-		fmt.Printf("  Owner:          %s\n", endpoint.OwnerString)
+		fmt.Printf("  Owner:          %s\n", endpoint.Owner)
 		fmt.Printf("  Description:    %s\n", endpoint.Description)
 		fmt.Printf("  Activated:      %t\n", endpoint.Activated)
-		fmt.Printf("  Connected:      %t\n", endpoint.GCPConnected)
-		fmt.Printf("  Default Dir:    %s\n", endpoint.DefaultDirectory)
-
-		// We don't have access to these fields in SDK v0.9.17
-		// Display the available information only
+		fmt.Printf("  Public:         %t\n", endpoint.Public)
 
 		// Organization and department if available
 		if endpoint.Organization != "" {
@@ -294,9 +224,8 @@ func showEndpoint(cmd *cobra.Command, endpointID string) error {
 			fmt.Printf("  Department:     %s\n", endpoint.Department)
 		}
 
-		// Contact info if available
-		if endpoint.ContactEmail != "" {
-			fmt.Printf("  Contact Email:  %s\n", endpoint.ContactEmail)
+		if endpoint.SubscriptionID != "" {
+			fmt.Printf("  Subscription:   %s\n", endpoint.SubscriptionID)
 		}
 	}
 

--- a/cmd/transfer/ls.go
+++ b/cmd/transfer/ls.go
@@ -11,11 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/transfer"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
 )
 
 var (
@@ -70,56 +67,23 @@ func parseEndpointAndPath(s string) (endpointID, path string) {
 
 // listDirectory lists the contents of a directory on an endpoint
 func listDirectory(cmd *cobra.Command, endpointID, path string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration - not used with direct client initialization in v0.9.17
-	// We still load it for future use cases
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer for v0.9.17
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for v0.9.17 compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create transfer client with v0.9.17 compatible options
-	transferOptions := []transfer.Option{
-		transfer.WithAuthorizer(coreAuthorizer),
-	}
-
-	transferClient, err := transfer.NewClient(transferOptions...)
-	if err != nil {
-		return fmt.Errorf("failed to create transfer client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Prepare listing options
 	options := &transfer.ListDirectoryOptions{
-		EndpointID: endpointID,
-		Path:       path,
 		ShowHidden: lsShowHidden,
 	}
 
 	// Get the directory listing
-	listing, err := transferClient.ListDirectory(ctx, options)
+	listing, err := transferClient.ListDirectory(ctx, endpointID, path, options)
 	if err != nil {
 		return fmt.Errorf("failed to list directory: %w", err)
 	}
@@ -164,12 +128,9 @@ func listDirectory(cmd *cobra.Command, endpointID, path string) error {
 			entry.Group = item.Group
 			entry.Size = item.Size
 
-			// Format last modified time
-			t, err := time.Parse(time.RFC3339, item.LastModified)
-			if err == nil {
-				entry.LastModified = t.Format("Jan 02 15:04")
-			} else {
-				entry.LastModified = item.LastModified
+			// Format last modified time (v4 exposes this as time.Time).
+			if !item.LastModified.IsZero() {
+				entry.LastModified = item.LastModified.Format("Jan 02 15:04")
 			}
 		}
 

--- a/cmd/transfer/mkdir.go
+++ b/cmd/transfer/mkdir.go
@@ -8,12 +8,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/transfer"
 )
 
 var (
@@ -55,56 +49,20 @@ Examples:
 
 // createDirectory creates a directory on an endpoint
 func createDirectory(cmd *cobra.Command, endpointID, path string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration - not used with direct client initialization in v0.9.17
-	// We still load it for future use cases
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer for v0.9.17
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for v0.9.17 compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create transfer client with v0.9.17 compatible options
-	transferOptions := []transfer.Option{
-		transfer.WithAuthorizer(coreAuthorizer),
-	}
-
-	transferClient, err := transfer.NewClient(transferOptions...)
-	if err != nil {
-		return fmt.Errorf("failed to create transfer client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Create directory options
-	options := &transfer.CreateDirectoryOptions{
-		EndpointID: endpointID,
-		Path:       path,
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
 	}
 
-	// Create the directory
-	err = transferClient.CreateDirectory(ctx, options)
-	if err != nil {
+	// Create the directory. The v4 SDK takes endpoint/path/local-user
+	// positionally; the recursive flag is a client-side convenience that the
+	// operation API does not accept, so it is a no-op for now.
+	if _, err := transferClient.MakeDirectory(ctx, endpointID, path, ""); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 

--- a/cmd/transfer/rm.go
+++ b/cmd/transfer/rm.go
@@ -10,12 +10,8 @@ import (
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/transfer"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
 )
 
 var (
@@ -59,56 +55,22 @@ Examples:
 
 // removeItem removes a file or directory on an endpoint
 func removeItem(cmd *cobra.Command, endpointID, path string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration - not used with direct client initialization in v0.9.17
-	// We still load it for future use cases
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer for v0.9.17
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for v0.9.17 compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create transfer client with v0.9.17 compatible options
-	transferOptions := []transfer.Option{
-		transfer.WithAuthorizer(coreAuthorizer),
-	}
-
-	transferClient, err := transfer.NewClient(transferOptions...)
-	if err != nil {
-		return fmt.Errorf("failed to create transfer client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Check if we need to prompt for confirmation
 	if !rmForce {
 		// Get file/directory info
-		options := &transfer.ListDirectoryOptions{
-			EndpointID: endpointID,
-			Path:       path,
-		}
+		options := &transfer.ListDirectoryOptions{}
 
-		listing, err := transferClient.ListDirectory(ctx, options)
+		listing, err := transferClient.ListDirectory(ctx, endpointID, path, options)
 		if err != nil {
 			// If we can't get info, still prompt
 			prompt := fmt.Sprintf("Are you sure you want to delete %s:%s?", endpointID, path)
@@ -152,21 +114,25 @@ func removeItem(cmd *cobra.Command, endpointID, path string) error {
 		}
 	}
 
-	// Delete the item using a delete task request for v0.9.17
-	deleteItem := transfer.DeleteItem{
-		DataType: "delete_item",
-		Path:     path,
-		// Note: In SDK v0.9.17, recursive is handled at the task level
+	// Submit a delete task. The v4 SDK carries recursion on the Delete request
+	// itself, and requires a submission ID minted from the service.
+	submissionID, err := transferClient.GetSubmissionID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get submission ID: %w", err)
 	}
 
-	deleteRequest := &transfer.DeleteTaskRequest{
-		DataType:   "delete",
-		EndpointID: endpointID,
-		Items:      []transfer.DeleteItem{deleteItem},
+	deleteRequest := &transfer.Delete{
+		DATA_TYPE:    "delete",
+		SubmissionID: submissionID,
+		Endpoint:     endpointID,
+		Recursive:    rmRecursive,
+		Items: []transfer.DeleteItem{
+			{DATA_TYPE: "delete_item", Path: path},
+		},
 	}
 
 	// Create a delete task
-	taskResponse, err := transferClient.CreateDeleteTask(ctx, deleteRequest)
+	taskResponse, err := transferClient.SubmitDelete(ctx, deleteRequest)
 	if err != nil {
 		return fmt.Errorf("failed to delete item: %w", err)
 	}

--- a/cmd/transfer/task.go
+++ b/cmd/transfer/task.go
@@ -12,11 +12,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	authcmd "github.com/scttfrdmn/globus-go-cli/cmd/auth"
-	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/core/authorizers"
-	"github.com/scttfrdmn/globus-go-sdk/v3/pkg/services/transfer"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
 )
 
 var (
@@ -126,54 +123,24 @@ showing progress information while waiting.`,
 
 // listTasks lists transfer tasks
 func listTasks(cmd *cobra.Command) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer for v0.9.17
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for v0.9.17 compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create transfer client with v0.9.17 compatible options
-	transferOptions := []transfer.Option{
-		transfer.WithAuthorizer(coreAuthorizer),
-	}
-
-	transferClient, err := transfer.NewClient(transferOptions...)
-	if err != nil {
-		return fmt.Errorf("failed to create transfer client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Prepare options for listing tasks
 	options := &transfer.ListTasksOptions{
 		Limit: limit,
 	}
 
-	// Add filters based on flags
+	// Add filters based on flags (v4 accepts a list of statuses)
 	if taskFilter != "" {
-		options.FilterStatus = taskFilter
+		options.FilterStatus = []string{taskFilter}
 	}
 
 	// Get the tasks
@@ -205,13 +172,13 @@ func listTasks(cmd *cobra.Command) error {
 
 	for _, task := range tasks.Data {
 		source := "N/A"
-		if task.SourceEndpointID != "" {
-			source = fmt.Sprintf("%s:%s", task.SourceEndpointID, task.SourceEndpointDisplay)
+		if task.SourceEndpoint != "" {
+			source = task.SourceEndpoint
 		}
 
 		destination := "N/A"
-		if task.DestinationEndpointID != "" {
-			destination = fmt.Sprintf("%s:%s", task.DestinationEndpointID, task.DestEndpointDisplay)
+		if task.DestinationEndpoint != "" {
+			destination = task.DestinationEndpoint
 		}
 
 		entry := taskEntry{
@@ -241,45 +208,15 @@ func showTask(cmd *cobra.Command, taskID string) error {
 		return waitForTask(cmd, taskID, taskWaitTime)
 	}
 
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer for v0.9.17
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for v0.9.17 compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create transfer client with v0.9.17 compatible options
-	transferOptions := []transfer.Option{
-		transfer.WithAuthorizer(coreAuthorizer),
-	}
-
-	transferClient, err := transfer.NewClient(transferOptions...)
-	if err != nil {
-		return fmt.Errorf("failed to create transfer client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get the task
 	task, err := transferClient.GetTask(ctx, taskID)
@@ -303,47 +240,39 @@ func showTask(cmd *cobra.Command, taskID string) error {
 		fmt.Printf("  Type:           %s\n", task.Type)
 		fmt.Printf("  Label:          %s\n", task.Label)
 
-		// Format dates - RequestTime is now time.Time in SDK v0.9.17
+		// Format dates - RequestTime is time.Time in the v4 SDK.
 		fmt.Printf("  Request Time:   %s\n", task.RequestTime.Format("2006-01-02 15:04:05"))
 
-		// CompletionTime is now *time.Time in SDK v0.9.17
-		if task.CompletionTime != nil {
+		// CompletionTime is time.Time in v4; zero means not yet complete.
+		if !task.CompletionTime.IsZero() {
 			fmt.Printf("  Completion Time: %s\n", task.CompletionTime.Format("2006-01-02 15:04:05"))
 		}
 
 		// Format task status with color
-		if task.Status == "SUCCEEDED" {
+		switch task.Status {
+		case "SUCCEEDED":
 			color.Green("  Task succeeded")
-		} else if task.Status == "FAILED" {
-			// NiceStatus field is not available in SDK v0.9.17
-			color.Red("  Task failed")
-		} else if task.Status == "ACTIVE" {
+		case "FAILED":
+			if task.NiceStatus != "" {
+				color.Red("  Task failed: %s", task.NiceStatus)
+			} else {
+				color.Red("  Task failed")
+			}
+		case "ACTIVE":
 			color.Yellow("  Task is active")
 		}
 
 		// Show endpoint information
 		fmt.Println("\nEndpoints:")
-		fmt.Printf("  Source:      %s (%s)\n", task.SourceEndpointDisplay, task.SourceEndpointID)
-		fmt.Printf("  Destination: %s (%s)\n", task.DestEndpointDisplay, task.DestinationEndpointID)
+		fmt.Printf("  Source:      %s\n", task.SourceEndpoint)
+		fmt.Printf("  Destination: %s\n", task.DestinationEndpoint)
 
 		// Show transfer stats
 		fmt.Println("\nTransfer Stats:")
 		fmt.Printf("  Files:          %d\n", task.FilesTransferred)
-		fmt.Printf("  Directories:    %d\n", task.Subtasks) // DirectoriesTransferred is not available in v0.9.17, using Subtasks instead
+		fmt.Printf("  Directories:    %d\n", task.Directories)
 		fmt.Printf("  Files Skipped:  %d\n", task.FilesSkipped)
-		fmt.Printf("  Total Files:    %d\n", task.Subtasks)                           // Using Subtasks as approximation for total files
-		fmt.Printf("  Total Bytes:    %d\n", task.BytesSkipped+task.BytesTransferred) // Approximation for total bytes
 		fmt.Printf("  Bytes Transferred: %d\n", task.BytesTransferred)
-
-		// Show sync options if applicable
-		if task.SyncLevel > 0 {
-			fmt.Printf("\nSynchronization Level: %d\n", task.SyncLevel)
-		}
-
-		// Show verification if applicable
-		if task.VerifyChecksum {
-			fmt.Printf("\nVerification: checksum\n")
-		}
 	}
 
 	return nil
@@ -351,45 +280,15 @@ func showTask(cmd *cobra.Command, taskID string) error {
 
 // cancelTask cancels a task
 func cancelTask(cmd *cobra.Command, taskID string) error {
-	// Get current profile
-	profile := viper.GetString("profile")
-
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
-	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer for v0.9.17
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for v0.9.17 compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create transfer client with v0.9.17 compatible options
-	transferOptions := []transfer.Option{
-		transfer.WithAuthorizer(coreAuthorizer),
-	}
-
-	transferClient, err := transfer.NewClient(transferOptions...)
-	if err != nil {
-		return fmt.Errorf("failed to create transfer client: %w", err)
-	}
-
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Get the current task status first
 	task, err := transferClient.GetTask(ctx, taskID)
@@ -415,40 +314,14 @@ func cancelTask(cmd *cobra.Command, taskID string) error {
 
 // waitForTask waits for a task to complete
 func waitForTask(cmd *cobra.Command, taskID string, timeout int) error {
-	// Get current profile
-	profile := viper.GetString("profile")
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
 
-	// Load token
-	tokenInfo, err := authcmd.LoadToken(profile)
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
 	if err != nil {
-		return fmt.Errorf("not logged in: %w", err)
-	}
-
-	// Check if token is valid
-	if !authcmd.IsTokenValid(tokenInfo) {
-		return fmt.Errorf("token is expired, please login again")
-	}
-
-	// Load client configuration
-	_, err = config.LoadClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load client configuration: %w", err)
-	}
-
-	// Create a simple static token authorizer for v0.9.17
-	tokenAuthorizer := authorizers.NewStaticTokenAuthorizer(tokenInfo.AccessToken)
-
-	// Create a core authorizer adapter for v0.9.17 compatibility
-	coreAuthorizer := authorizers.ToCore(tokenAuthorizer)
-
-	// Create transfer client with v0.9.17 compatible options
-	transferOptions := []transfer.Option{
-		transfer.WithAuthorizer(coreAuthorizer),
-	}
-
-	transferClient, err := transfer.NewClient(transferOptions...)
-	if err != nil {
-		return fmt.Errorf("failed to create transfer client: %w", err)
+		return err
 	}
 
 	// Start spinner
@@ -456,10 +329,6 @@ func waitForTask(cmd *cobra.Command, taskID string, timeout int) error {
 	s.Suffix = fmt.Sprintf(" Waiting for task %s to complete...", taskID)
 	s.Start()
 	defer s.Stop()
-
-	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
-	defer cancel()
 
 	// Poll for task completion
 	pollInterval := 5 * time.Second
@@ -479,8 +348,8 @@ func waitForTask(cmd *cobra.Command, taskID string, timeout int) error {
 
 			// Update spinner message
 			if task.FilesTransferred > 0 || task.BytesTransferred > 0 {
-				s.Suffix = fmt.Sprintf(" Waiting for task %s: %d/%d files, %d/%d bytes",
-					taskID, task.FilesTransferred, task.Subtasks, task.BytesTransferred, task.BytesSkipped+task.BytesTransferred)
+				s.Suffix = fmt.Sprintf(" Waiting for task %s: %d files, %d bytes transferred",
+					taskID, task.FilesTransferred, task.BytesTransferred)
 			}
 
 			// Check if the task has completed

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -14,8 +14,31 @@ service; the Python CLI is flatter, e.g. top-level `task`, `bookmark`,
 - **Go CLI:** ~112 command paths across auth, transfer, search, groups, flows,
   compute, timer, config.
 
-Note the version numbers are independent: the Go CLI tracks the Globus **SDK**
-(Python globus-sdk 3.65.0), while the Python **CLI** versions separately (3.42.0).
+Note the version numbers are independent: the Go CLI tracks the Globus **SDK**,
+while the Python **CLI** versions separately (3.42.0).
+
+## SDK backing: v4 migration (Phase 2b)
+
+The backable service command groups — **transfer, groups, search, flows,
+compute, timer** — now build on the **v4 Go SDK** (`globus-go-sdk/v4`, tracking
+Python globus-sdk 4.8.1) with per-resource-server GlobusApp tokens, replacing
+the previous v3 SDK + single-combined-token model. Each package has a
+`client.go` `getClient(ctx)` helper over `pkg/globusauth`.
+
+The v4 models differ from v3 in places, so a few flags are retained for
+command-surface stability but are currently **no-ops** (they do not map to a v4
+request field):
+
+- `flows update --public`; `flows` create/update auth-policy flags
+  (`--high-assurance`, `--required-mfa`, `--session-policies`) and run-list
+  `--orderby` (v4 run list has no server-side orderby; `--status` is filtered
+  client-side).
+- `search` index create/update `--monitored` / `--active` (v4 `IndexCreate`/
+  `IndexUpdate` carry only display name + description).
+
+The **auth** package (`login` already uses v4 GlobusApp; `device`, `logout`,
+`refresh`, `tokens`, `whoami`) and `root.go` still reference the v3 SDK and the
+transitional legacy-token bridge — a separate follow-up (Phase 2c).
 
 ## Coverage by area
 
@@ -67,12 +90,13 @@ hasn't wired up commands yet:
 
 ### B. Gaps with no v3 SDK support (need SDK work first, or are out of scope)
 
-- **GCS / collections management** (`collection`, `gcs`, ~32 commands) — there is
-  **no v3 `gcs` service** in the Go SDK. The v4 SDK module has a `gcs` service;
-  full support would require either a v4-based CLI or a v3 gcs port.
+- **GCS / collections management** (`collection`, `gcs`, ~32 commands) — the v4
+  SDK module has a `gcs` service. Now that the service commands build on v4
+  (Phase 2b), wiring these up is CLI work rather than an SDK blocker.
 - **GCP (Globus Connect Personal)** — local-agent management; not an SDK API.
-- **Streams / tunnels** — a Python globus-sdk v4.3.0+ feature, absent from the
-  frozen v3 SDK. Present as "unavailable" stubs.
+- **Streams / tunnels** — a Python globus-sdk v4.3.0+ feature. The v4 Go SDK
+  transfer client now exposes tunnel/stream-access-point methods, so these are
+  becoming supportable; the CLI currently ships "unavailable" stubs.
 - **`api` raw passthrough** — convenience for arbitrary API calls; no SDK method,
   would be a thin HTTP wrapper.
 

--- a/pkg/globusauth/app.go
+++ b/pkg/globusauth/app.go
@@ -161,3 +161,25 @@ func Authorizer(ctx context.Context, profile, clientID, clientSecret string, svc
 	}
 	return authz, nil
 }
+
+// ClientConfig builds a v4 SDK *core.Config authorized for the given service
+// from the stored tokens of the profile. Pass the result straight to a service
+// package's NewClient(ctx, cfg), e.g.:
+//
+//	cfg, err := globusauth.ClientConfig(ctx, profile, clientID, secret, globusauth.ServiceTransfer)
+//	client, err := transfer.NewClient(ctx, cfg)
+//
+// The returned config carries the auto-refreshing per-resource-server
+// authorizer and the service's scope, so every migrated command constructs its
+// client the same way.
+func ClientConfig(ctx context.Context, profile, clientID, clientSecret string, svc Service) (*core.Config, error) {
+	authz, err := Authorizer(ctx, profile, clientID, clientSecret, svc)
+	if err != nil {
+		return nil, err
+	}
+	cfg := &core.Config{Authorizer: authz}
+	if scope, ok := Scope(svc); ok {
+		cfg.Scopes = []string{scope}
+	}
+	return cfg, nil
+}


### PR DESCRIPTION
## Phase 2b — migrate backable service commands from the v3 SDK to the v4 SDK

Moves all six backable service command groups off the v3 SDK + legacy
single-combined-token bridge and onto the **v4 SDK** with per-resource-server
**GlobusApp** tokens (`pkg/globusauth`). Each package now has a `client.go`
`getClient(ctx)` helper that builds its client via
`globusauth.ClientConfig(...) -> svc.NewClient(ctx, cfg)`, replacing the
~30-line `LoadToken -> StaticTokenAuthorizer -> ToCore -> NewClient(WithAuthorizer)`
recipe that was copy-pasted into every subcommand (transfer's `task.go` alone
had it four times). Net **−1400 LOC**.

### Foundational fix (was blocking any v4 read path)
The legacy bridge (`saveToken`) and the v4 GlobusApp store both wrote
`~/.globus-cli/tokens/<profile>.json`, and `login` ran `saveToken` **after**
`userApp.Login()`, so the flat legacy blob overwrote the v4 namespaced store —
any command reading the v4 store would then fail. The bridge now lives at
`<profile>-legacy.json`; both writer and reader route through the same
`GetTokenFilePathFunc`. Adds `globusauth.ClientConfig(...)`.

### Services migrated
- **transfer** (6 files) — pilot. v4 API: `ListDirectory(ctx, ep, path, opts)`,
  `MakeDirectory`, struct-based `SubmitTransfer`/`SubmitDelete` with a
  service-minted submission ID, `EndpointSearch`, Task/Endpoint field renames.
- **group** (8) — `GetMyGroups` returns `[]Group` directly in v4.
- **compute** (6) — no API changes (already map-based).
- **timer** (6) — no API changes; import path only.
- **search** (11) — v4 redesign: `IndexList`/`SearchGet`/`Ingest`/`DeleteSubject`/
  `GetTask`, `GetSubject` for subject show, Index/IngestResponse field changes.
- **flows** (12) — v4 model changes: `RunFlow(flowID, *FlowInput)`,
  `FlowCreate`/`FlowUpdate` (no `Public`/auth-policy fields), `GetRun`/`GetRunLogs`
  option args, `FlowRun.StartTime/EndTime/Details`, client-side run status filter.

Stub commands (unsupported/parent-only) are untouched. The **auth** package
(`device`/`logout`/`refresh`/`tokens`/`whoami`) and `root.go` remain on v3 — they
define/consume the legacy bridge and are a separate follow-up (Phase 2c).

### Flags now no-op (retained for surface stability)
`flows update --public` + auth-policy/orderby flags; `search` index
`--monitored`/`--active`. Documented in `docs/PYTHON_CLI_PARITY.md`.

### Verification
`GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues — all
against the **published** `v4.8.1-1` SDK release (not just the local workspace).