### PR TITLE
feat: flatten command structure to match Python Globus CLI (Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,28 +93,28 @@ mv globus /usr/local/bin/
 
 ```bash
 # Login to Globus
-globus auth login
+globus login
 
 # Or login without a browser
-globus auth device
+globus device
 
 # Show information about the current user
-globus auth whoami
+globus whoami
 
 # List your endpoints
-globus transfer endpoint list
+globus endpoint list
 
 # List files on an endpoint
-globus transfer ls ENDPOINT_ID:/path
+globus ls ENDPOINT_ID:/path
 
 # Transfer files between endpoints
-globus transfer cp SOURCE_ENDPOINT:/source/path DEST_ENDPOINT:/dest/path
+globus transfer SOURCE_ENDPOINT:/source/path DEST_ENDPOINT:/dest/path
 
 # Check transfer status
-globus transfer task show TASK_ID
+globus task show TASK_ID
 
 # Logout when done
-globus auth logout
+globus logout
 ```
 
 ## Configuration
@@ -146,13 +146,13 @@ Most commands support different output formats:
 
 ```bash
 # Default text format
-globus transfer endpoint list
+globus endpoint list
 
 # JSON output for scripting
-globus transfer endpoint list --format=json
+globus endpoint list --format=json
 
 # CSV output for importing into spreadsheets
-globus transfer endpoint list --format=csv
+globus endpoint list --format=csv
 ```
 
 ## Detailed Command Reference
@@ -161,69 +161,69 @@ globus transfer endpoint list --format=csv
 
 ```bash
 # Log in using browser
-globus auth login
+globus login
 
 # Log in with device code (no browser)
-globus auth device
+globus device
 
 # Show current user info
-globus auth whoami
+globus whoami
 
 # List tokens
-globus auth tokens show
+globus tokens show
 
 # Refresh tokens
-globus auth refresh
+globus refresh
 
 # Revoke tokens
-globus auth tokens revoke --type=access
+globus tokens revoke --type=access
 
 # Look up identities
-globus auth identities lookup user@example.com
+globus get-identities user@example.com
 
 # Log out
-globus auth logout
+globus logout
 ```
 
 ### Transfer Commands
 
 ```bash
 # List endpoints
-globus transfer endpoint list
+globus endpoint list
 
 # Search for endpoints
-globus transfer endpoint search "my data"
+globus endpoint search "my data"
 
 # Show endpoint details
-globus transfer endpoint show ENDPOINT_ID
+globus endpoint show ENDPOINT_ID
 
 # List files on endpoint
-globus transfer ls ENDPOINT_ID:/path
-globus transfer ls -l ENDPOINT_ID:/path  # long format
+globus ls ENDPOINT_ID:/path
+globus ls -l ENDPOINT_ID:/path  # long format
 
 # Create directory
-globus transfer mkdir ENDPOINT_ID:/new/directory
-globus transfer mkdir -p ENDPOINT_ID:/nested/directory  # create parents
+globus mkdir ENDPOINT_ID:/new/directory
+globus mkdir -p ENDPOINT_ID:/nested/directory  # create parents
 
 # Delete files/directories
-globus transfer rm ENDPOINT_ID:/path/to/file
-globus transfer rm -r ENDPOINT_ID:/directory  # recursive
+globus rm ENDPOINT_ID:/path/to/file
+globus rm -r ENDPOINT_ID:/directory  # recursive
 
 # Transfer files
-globus transfer cp SOURCE_EP:/file DEST_EP:/path
-globus transfer cp -r SOURCE_EP:/dir DEST_EP:/path  # recursive
+globus transfer SOURCE_EP:/file DEST_EP:/path
+globus transfer -r SOURCE_EP:/dir DEST_EP:/path  # recursive
 
 # List tasks
-globus transfer task list
+globus task list
 
 # View task details
-globus transfer task show TASK_ID
+globus task show TASK_ID
 
 # Wait for task completion
-globus transfer task wait TASK_ID
+globus task wait TASK_ID
 
 # Cancel task
-globus transfer task cancel TASK_ID
+globus task cancel TASK_ID
 ```
 
 ### Shell Completion

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -8,42 +8,17 @@ import (
 	"github.com/scttfrdmn/globus-go-cli/cmd/auth"
 )
 
-// getAuthCommand returns the auth command
-func getAuthCommand() *cobra.Command {
-	// authCmd represents the auth command
-	authCmd := &cobra.Command{
-		Use:   "auth",
-		Short: "Commands for Globus Auth",
-		Long: `Commands for working with Globus Auth including login, logout,
-token management, and identity operations.
-
-Available Commands:
-  login       Log in to Globus (web browser flow)
-  device      Log in using device code flow (no browser)
-  logout      Log out from Globus
-  refresh     Refresh access tokens
-  whoami      Show information about the current user
-  tokens      Manage Globus Auth tokens
-  identities  Look up and manage Globus identities
-
-Examples:
-  globus auth login                   Log in using a web browser
-  globus auth device                  Log in using device code (no browser)
-  globus auth whoami                  Show current user information
-  globus auth tokens show             Show current token information
-  globus auth identities lookup user  Look up a Globus identity by username`,
-	}
-
-	// Add auth subcommands
-	authCmd.AddCommand(
+// addAuthCommands wires the auth commands directly onto the root command as
+// flat top-level commands, matching the Python Globus CLI (globus login,
+// globus logout, globus whoami, globus get-identities, ...).
+func addAuthCommands(root *cobra.Command) {
+	root.AddCommand(
 		auth.LoginCmd(),
-		auth.DeviceCmd(),
 		auth.LogoutCmd(),
-		auth.RefreshCmd(),
 		auth.WhoamiCmd(),
+		auth.DeviceCmd(),
+		auth.RefreshCmd(),
 		auth.TokensCmd(),
-		auth.IdentitiesCmd(),
+		auth.GetIdentitiesCmd(),
 	)
-
-	return authCmd
 }

--- a/cmd/auth/identities.go
+++ b/cmd/auth/identities.go
@@ -35,6 +35,16 @@ managing Globus Auth identities.`,
 	return identitiesCmd
 }
 
+// GetIdentitiesCmd returns the flat top-level `get-identities` command, matching
+// the Python CLI's `globus get-identities`. It is the same lookup used by
+// `identities lookup`, exposed directly at the top level.
+func GetIdentitiesCmd() *cobra.Command {
+	cmd := identitiesLookupCmd()
+	cmd.Use = "get-identities [VALUES...]"
+	cmd.Short = "Look up Globus Auth identities"
+	return cmd
+}
+
 // Identity represents a Globus Auth identity
 type Identity struct {
 	ID         string `json:"id"`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -225,18 +225,28 @@ func OutputFormat() string { return viper.GetString("format") }
 // MapHTTPStatus returns the raw --map-http-status spec.
 func MapHTTPStatus() string { return mapHTTPStatus }
 
-// addServiceCommands adds all service commands to the root command
+// addServiceCommands adds all commands to the root command.
+//
+// The command tree is flat, matching the Python Globus CLI: auth and transfer
+// operations live at the top level (globus login, globus ls, globus task show,
+// globus endpoint ...) rather than nested under a service group. Services that
+// the Python CLI also groups (group, search, flows, timer) remain groups, as
+// does the Go-only compute extension and config.
 func addServiceCommands() {
-	// Import and add all service commands
+	// Flat auth commands (globus login/logout/whoami/...).
+	addAuthCommands(rootCmd)
+
+	// Flat transfer commands (globus ls/mkdir/rm/transfer/task/endpoint/...).
+	addTransferCommands(rootCmd)
+
+	// Grouped services (already flat-compatible with the Python CLI) and Go
+	// extensions.
 	rootCmd.AddCommand(
-		getAuthCommand(),
-		getTransferCommand(),
 		getGroupCommand(),
 		getTimerCommand(),
 		getSearchCommand(),
 		getFlowsCommand(),
 		getComputeCommand(),
-		// All services now implemented!
 		getConfigCommand(),
 	)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -60,3 +60,36 @@ func getRootCommandForTesting() *cobra.Command {
 
 	return cmd
 }
+
+// TestFlatCommandStructure asserts the top-level command tree is flat, matching
+// the Python Globus CLI: auth and transfer operations are top-level commands,
+// not nested under "auth"/"transfer" groups. Guards against a regression to the
+// old nested layout.
+func TestFlatCommandStructure(t *testing.T) {
+	cmd := Execute()
+
+	have := map[string]bool{}
+	for _, c := range cmd.Commands() {
+		// Command name is the first token of Use.
+		have[strings.Fields(c.Use)[0]] = true
+	}
+
+	// These must exist at the top level (flattened from auth/transfer).
+	wantTopLevel := []string{
+		"login", "logout", "whoami", "get-identities", "device", "refresh", "tokens",
+		"ls", "mkdir", "rm", "transfer", "task", "endpoint",
+		"group", "search", "flows", "timer", "compute", "config",
+	}
+	for _, name := range wantTopLevel {
+		if !have[name] {
+			t.Errorf("expected top-level command %q, but it is missing", name)
+		}
+	}
+
+	// The old service-group wrappers must NOT exist at the top level.
+	for _, name := range []string{"auth"} {
+		if have[name] {
+			t.Errorf("did not expect service group %q at the top level (should be flattened)", name)
+		}
+	}
+}

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -8,45 +8,19 @@ import (
 	"github.com/scttfrdmn/globus-go-cli/cmd/transfer"
 )
 
-// getTransferCommand returns the transfer command
-func getTransferCommand() *cobra.Command {
-	// transferCmd represents the transfer command
-	transferCmd := &cobra.Command{
-		Use:   "transfer",
-		Short: "Commands for Globus Transfer",
-		Long: `Commands for working with Globus Transfer including file operations,
-endpoint management, and transfer task handling.
-
-Available Commands:
-  endpoint    Manage Globus Transfer endpoints
-  ls          List directory contents on an endpoint
-  mkdir       Create a directory on an endpoint
-  rm          Remove files and directories from an endpoint
-  cp                  Transfer files between endpoints
-  task                Manage transfer tasks
-  tunnel              Manage Globus Streams tunnels
-  stream-access-point Manage Globus Streams access points
-
-Examples:
-  globus transfer endpoint list               List your endpoints
-  globus transfer endpoint search "my data"   Search for endpoints
-  globus transfer ls ENDPOINT_ID:/path        List files on an endpoint
-  globus transfer mkdir ENDPOINT_ID:/newdir   Create a directory
-  globus transfer cp SOURCE_EP:/file DEST_EP:/path   Transfer a file
-  globus transfer task show TASK_ID           Check transfer status`,
-	}
-
-	// Import transfer commands
-	transferCmd.AddCommand(
-		transfer.EndpointCmd(),
+// addTransferCommands wires the transfer commands directly onto the root
+// command as flat top-level commands, matching the Python Globus CLI (globus
+// ls, globus mkdir, globus rm, globus transfer, globus task ..., globus
+// endpoint ...).
+func addTransferCommands(root *cobra.Command) {
+	root.AddCommand(
 		transfer.LsCmd(),
 		transfer.MkdirCmd(),
-		transfer.CpCmd(),
 		transfer.RmCmd(),
+		transfer.CpCmd(), // exposed as the top-level `transfer` verb
 		transfer.TaskCmd(),
+		transfer.EndpointCmd(),
 		transfer.TunnelCmd(),
 		transfer.StreamAccessPointCmd(),
 	)
-
-	return transferCmd
 }

--- a/cmd/transfer/cp.go
+++ b/cmd/transfer/cp.go
@@ -29,7 +29,7 @@ var (
 // CpCmd returns the cp command
 func CpCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cp SOURCE_ENDPOINT:SOURCE_PATH DEST_ENDPOINT:DEST_PATH",
+		Use:   "transfer SOURCE_ENDPOINT:SOURCE_PATH DEST_ENDPOINT:DEST_PATH",
 		Short: "Transfer files between Globus endpoints",
 		Long: `Transfer files between Globus endpoints.
 

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -4,11 +4,16 @@
 # Parity with the upstream Python Globus CLI
 
 This tracks the Go CLI's command coverage against the reference
-[Globus CLI (Python)](https://github.com/globus/globus-cli). It is a
-functional comparison, not a 1:1 command-path map — the two CLIs organize
-commands differently (the Go CLI nests task/endpoint commands under each
-service; the Python CLI is flatter, e.g. top-level `task`, `bookmark`,
-`collection`, `endpoint`).
+[Globus CLI (Python)](https://github.com/globus/globus-cli).
+
+As of **Phase 3**, the Go CLI uses a **flat command structure matching the
+Python CLI**: auth and transfer operations are top-level commands, not nested
+under `auth`/`transfer` groups. So `globus login`, `globus logout`,
+`globus whoami`, `globus get-identities`, `globus ls`, `globus mkdir`,
+`globus rm`, `globus transfer SRC DEST`, `globus task show`, and
+`globus endpoint search` are all invoked exactly as in the Python CLI.
+`group`, `search`, `flows`, and `timer` remain command groups (the Python CLI
+groups these too); `compute` is a Go-only extension group.
 
 - **Python globus-cli compared:** 3.42.0 (latest at time of writing), 164 commands.
 - **Go CLI:** ~112 command paths across auth, transfer, search, groups, flows,

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -25,7 +25,7 @@ This opens your browser for authentication and stores credentials locally.
 View your current identity:
 
 ```bash
-globus auth whoami
+globus whoami
 ```
 
 Check session information:

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -70,7 +70,7 @@ See [Environment Variables](../guides/environment-variables.md) for a complete l
 Flags override both configuration and environment variables:
 
 ```bash
-globus auth whoami --format text
+globus whoami --format text
 ```
 
 ## Priority Order

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -35,7 +35,7 @@ You have successfully logged in to the Globus CLI!
 Check that you're logged in:
 
 ```bash
-globus auth whoami
+globus whoami
 ```
 
 This displays your identity information:
@@ -56,7 +56,7 @@ This displays your identity information:
 View endpoints you have access to:
 
 ```bash
-globus transfer endpoint list
+globus endpoint list
 ```
 
 ### View Endpoint Details
@@ -64,7 +64,7 @@ globus transfer endpoint list
 Get details about a specific endpoint:
 
 ```bash
-globus transfer endpoint show ENDPOINT_ID
+globus endpoint show ENDPOINT_ID
 ```
 
 Replace `ENDPOINT_ID` with an actual endpoint UUID.
@@ -74,7 +74,7 @@ Replace `ENDPOINT_ID` with an actual endpoint UUID.
 Browse files on an endpoint:
 
 ```bash
-globus transfer ls ENDPOINT_ID:/path/to/directory
+globus ls ENDPOINT_ID:/path/to/directory
 ```
 
 ### Transfer Files
@@ -82,7 +82,7 @@ globus transfer ls ENDPOINT_ID:/path/to/directory
 Transfer a file between two endpoints:
 
 ```bash
-globus transfer transfer \
+globus transfer \
   --source-endpoint SOURCE_ENDPOINT_ID \
   --dest-endpoint DEST_ENDPOINT_ID \
   --source-path /path/to/source/file.txt \
@@ -92,7 +92,7 @@ globus transfer transfer \
 Check transfer status:
 
 ```bash
-globus transfer task show TASK_ID
+globus task show TASK_ID
 ```
 
 ## Output Formats
@@ -102,13 +102,13 @@ The CLI supports multiple output formats:
 ### JSON Output (Default)
 
 ```bash
-globus auth whoami --format json
+globus whoami --format json
 ```
 
 ### Text Output
 
 ```bash
-globus auth whoami --format text
+globus whoami --format text
 ```
 
 ### Quiet Mode
@@ -116,7 +116,7 @@ globus auth whoami --format text
 For scripting, use quiet mode to get minimal output:
 
 ```bash
-globus transfer task list --format json --limit 1 | jq -r '.[0].task_id'
+globus task list --format json --limit 1 | jq -r '.[0].task_id'
 ```
 
 ## Common Options
@@ -152,7 +152,7 @@ Get help for any command:
 ```bash
 globus --help
 globus transfer --help
-globus transfer task list --help
+globus task list --help
 ```
 
 ### Available Commands
@@ -163,10 +163,10 @@ List all available commands:
 globus --help
 ```
 
-Main command groups:
+Main commands and groups:
 
-- `auth` - Authentication and identity management
-- `transfer` - File transfer operations
+- `login` / `logout` / `whoami` - Authentication and identity management
+- `transfer` / `ls` / `mkdir` / `rm` / `task` / `endpoint` - File transfer operations
 - `search` - Search index management
 - `groups` - Group membership management
 - `flows` - Workflow automation

--- a/docs/guides/common-tasks.md
+++ b/docs/guides/common-tasks.md
@@ -7,7 +7,7 @@ Practical examples for common operations with the Globus Go CLI.
 ### Transfer a Single File
 
 ```bash
-globus transfer transfer \
+globus transfer \
   --source-endpoint abc12345-6789-0def-ghij-klmnopqrstuv \
   --dest-endpoint xyz67890-abcd-efgh-ijkl-mnopqrstuvwx \
   --source-path /data/file.txt \
@@ -18,7 +18,7 @@ globus transfer transfer \
 ### Transfer a Directory Recursively
 
 ```bash
-globus transfer transfer \
+globus transfer \
   --source-endpoint abc12345-6789-0def-ghij-klmnopqrstuv \
   --dest-endpoint xyz67890-abcd-efgh-ijkl-mnopqrstuvwx \
   --source-path /data/mydir/ \
@@ -34,10 +34,10 @@ globus transfer transfer \
 TASK_ID="01234567-89ab-cdef-0123-456789abcdef"
 
 # Check task status
-globus transfer task show $TASK_ID
+globus task show $TASK_ID
 
 # List all active tasks
-globus transfer task list --filter-status ACTIVE
+globus task list --filter-status ACTIVE
 ```
 
 ### Sync Directories
@@ -45,7 +45,7 @@ globus transfer task list --filter-status ACTIVE
 Use sync level to avoid re-transferring unchanged files:
 
 ```bash
-globus transfer transfer \
+globus transfer \
   --source-endpoint abc12345-6789-0def-ghij-klmnopqrstuv \
   --dest-endpoint xyz67890-abcd-efgh-ijkl-mnopqrstuvwx \
   --source-path /data/ \
@@ -68,19 +68,19 @@ Sync levels:
 Search for endpoints by name or keyword:
 
 ```bash
-globus transfer endpoint search "Tutorial"
+globus endpoint search "Tutorial"
 ```
 
 ### List Your Endpoints
 
 ```bash
-globus transfer endpoint list --filter-scope my-endpoints
+globus endpoint list --filter-scope my-endpoints
 ```
 
 ### Get Endpoint Details
 
 ```bash
-globus transfer endpoint show abc12345-6789-0def-ghij-klmnopqrstuv
+globus endpoint show abc12345-6789-0def-ghij-klmnopqrstuv
 ```
 
 ## Browsing Files
@@ -88,13 +88,13 @@ globus transfer endpoint show abc12345-6789-0def-ghij-klmnopqrstuv
 ### List Directory Contents
 
 ```bash
-globus transfer ls abc12345-6789-0def-ghij-klmnopqrstuv:/data/
+globus ls abc12345-6789-0def-ghij-klmnopqrstuv:/data/
 ```
 
 ### Show File Details
 
 ```bash
-globus transfer ls abc12345-6789-0def-ghij-klmnopqrstuv:/data/file.txt --long
+globus ls abc12345-6789-0def-ghij-klmnopqrstuv:/data/file.txt --long
 ```
 
 ## Using Output with jq
@@ -102,7 +102,7 @@ globus transfer ls abc12345-6789-0def-ghij-klmnopqrstuv:/data/file.txt --long
 ### Extract Task ID
 
 ```bash
-TASK_ID=$(globus transfer transfer \
+TASK_ID=$(globus transfer \
   --source-endpoint SRC \
   --dest-endpoint DST \
   --source-path /src/path \
@@ -115,13 +115,13 @@ echo "Task ID: $TASK_ID"
 ### Count Active Tasks
 
 ```bash
-globus transfer task list --filter-status ACTIVE --format json | jq 'length'
+globus task list --filter-status ACTIVE --format json | jq 'length'
 ```
 
 ### Extract Endpoint IDs
 
 ```bash
-globus transfer endpoint list --format json | jq -r '.[].id'
+globus endpoint list --format json | jq -r '.[].id'
 ```
 
 ## Automation and Scripting
@@ -133,7 +133,7 @@ globus transfer endpoint list --format json | jq -r '.[].id'
 FILES="file1.txt file2.txt file3.txt"
 
 for file in $FILES; do
-  globus transfer transfer \
+  globus transfer \
     --source-endpoint $SRC_EP \
     --dest-endpoint $DST_EP \
     --source-path "/data/$file" \
@@ -149,7 +149,7 @@ done
 TASK_ID=$1
 
 while true; do
-  STATUS=$(globus transfer task show $TASK_ID --format json | jq -r '.status')
+  STATUS=$(globus task show $TASK_ID --format json | jq -r '.status')
 
   if [ "$STATUS" = "SUCCEEDED" ]; then
     echo "Transfer completed successfully"

--- a/docs/guides/environment-variables.md
+++ b/docs/guides/environment-variables.md
@@ -83,8 +83,8 @@ export GLOBUS_CLIENT_ID=abc123
 export GLOBUS_CLIENT_SECRET=secret456
 
 # Run commands
-globus auth whoami
-globus transfer endpoint list
+globus whoami
+globus endpoint list
 ```
 
 ### Python Example

--- a/docs/guides/migration.md
+++ b/docs/guides/migration.md
@@ -27,8 +27,8 @@ The Go CLI maintains command compatibility with the Python CLI. Most commands wo
 ```bash
 # These work the same in both CLIs
 globus login
-globus auth whoami
-globus transfer task list
+globus whoami
+globus task list
 globus search index list
 ```
 
@@ -119,7 +119,7 @@ source <(globus completion bash)
 ## Migration Checklist
 
 - [ ] Install Go CLI using preferred method
-- [ ] Verify authentication works: `globus auth whoami`
+- [ ] Verify authentication works: `globus whoami`
 - [ ] Test critical commands from your scripts
 - [ ] Update scripts to specify `--format` explicitly
 - [ ] Update shell completion configuration

--- a/docs/guides/output-formats.md
+++ b/docs/guides/output-formats.md
@@ -9,7 +9,7 @@ The Globus Go CLI supports multiple output formats for different use cases.
 Machine-readable JSON output, ideal for parsing and automation:
 
 ```bash
-globus auth whoami --format json
+globus whoami --format json
 ```
 
 Output:
@@ -28,7 +28,7 @@ Output:
 Human-readable tabular output:
 
 ```bash
-globus auth whoami --format text
+globus whoami --format text
 ```
 
 Output:
@@ -57,7 +57,7 @@ export GLOBUS_CLI_FORMAT=json
 ### Via Flag
 
 ```bash
-globus auth whoami --format text
+globus whoami --format text
 ```
 
 ## Parsing JSON Output
@@ -68,20 +68,20 @@ Extract specific fields:
 
 ```bash
 # Get just the username
-globus auth whoami --format json | jq -r '.username'
+globus whoami --format json | jq -r '.username'
 
 # Get identity ID
-globus auth whoami --format json | jq -r '.identity_id'
+globus whoami --format json | jq -r '.identity_id'
 ```
 
 List processing:
 
 ```bash
 # Get all endpoint IDs
-globus transfer endpoint list --format json | jq -r '.[].id'
+globus endpoint list --format json | jq -r '.[].id'
 
 # Get endpoint names and IDs
-globus transfer endpoint list --format json | \
+globus endpoint list --format json | \
   jq -r '.[] | "\(.display_name): \(.id)"'
 ```
 
@@ -109,16 +109,16 @@ Don't rely on defaults in scripts:
 
 ```bash
 # Good
-globus auth whoami --format json
+globus whoami --format json
 
 # Avoid
-globus auth whoami
+globus whoami
 ```
 
 ### Check Exit Codes
 
 ```bash
-if globus auth whoami --format json > /dev/null 2>&1; then
+if globus whoami --format json > /dev/null 2>&1; then
   echo "Authenticated"
 else
   echo "Not authenticated"
@@ -129,7 +129,7 @@ fi
 ### Handle Errors
 
 ```bash
-output=$(globus transfer task show $TASK_ID --format json 2>&1)
+output=$(globus task show $TASK_ID --format json 2>&1)
 
 if [ $? -ne 0 ]; then
   echo "Error: $output"

--- a/docs/reference/auth.md
+++ b/docs/reference/auth.md
@@ -2,12 +2,12 @@
 
 Commands for authentication and identity management.
 
-## globus auth whoami
+## globus whoami
 
 Display information about the currently authenticated user.
 
 ```bash
-globus auth whoami [flags]
+globus whoami [flags]
 ```
 
 **Output:**

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,16 +4,16 @@ Complete reference documentation for all Globus Go CLI commands.
 
 ## Command Structure
 
-All commands follow this structure:
+Most commands follow this structure:
 
 ```bash
-globus <service> <command> [subcommand] [flags]
+globus <command> [subcommand] [flags]
 ```
 
 Example:
 
 ```bash
-globus transfer task list --limit 10
+globus task list --limit 10
 ```
 
 ## Available Services
@@ -25,7 +25,7 @@ The CLI provides commands for these Globus services:
 Authentication and identity management.
 
 ```bash
-globus auth whoami
+globus whoami
 globus login
 globus logout
 ```
@@ -35,9 +35,9 @@ globus logout
 File and directory transfer operations.
 
 ```bash
-globus transfer task list
-globus transfer ls ENDPOINT_ID:/path
-globus transfer transfer --source-endpoint SRC --dest-endpoint DST ...
+globus task list
+globus ls ENDPOINT_ID:/path
+globus transfer --source-endpoint SRC --dest-endpoint DST ...
 ```
 
 ### [Search Commands](search.md)
@@ -104,7 +104,7 @@ These flags are available for all commands:
 Default output format, suitable for parsing:
 
 ```bash
-globus auth whoami --format json
+globus whoami --format json
 ```
 
 Output:
@@ -122,7 +122,7 @@ Output:
 Human-readable tabular output:
 
 ```bash
-globus auth whoami --format text
+globus whoami --format text
 ```
 
 ## Getting Help
@@ -134,10 +134,10 @@ Get help for any command:
 globus transfer --help
 
 # Command-level help
-globus transfer task --help
+globus task --help
 
 # Subcommand-level help
-globus transfer task list --help
+globus task list --help
 ```
 
 ## Exit Codes

--- a/docs/reference/transfer.md
+++ b/docs/reference/transfer.md
@@ -13,26 +13,26 @@ The Transfer service provides commands for:
 
 ## Common Commands
 
-### globus transfer ls
+### globus ls
 
 List contents of a directory on an endpoint.
 
 ```bash
-globus transfer ls ENDPOINT_ID:/path [flags]
+globus ls ENDPOINT_ID:/path [flags]
 ```
 
 **Example:**
 
 ```bash
-globus transfer ls abc12345-6789-0def-ghij-klmnopqrstuv:/~/
+globus ls abc12345-6789-0def-ghij-klmnopqrstuv:/~/
 ```
 
-### globus transfer transfer
+### globus transfer
 
 Initiate a file or directory transfer.
 
 ```bash
-globus transfer transfer [flags]
+globus transfer [flags]
 ```
 
 **Required Flags:**
@@ -51,7 +51,7 @@ globus transfer transfer [flags]
 **Example:**
 
 ```bash
-globus transfer transfer \
+globus transfer \
   --source-endpoint abc12345-6789-0def-ghij-klmnopqrstuv \
   --dest-endpoint xyz67890-abcd-efgh-ijkl-mnopqrstuvwx \
   --source-path /path/to/source \
@@ -59,12 +59,12 @@ globus transfer transfer \
   --recursive
 ```
 
-### globus transfer task list
+### globus task list
 
 List recent transfer tasks.
 
 ```bash
-globus transfer task list [flags]
+globus task list [flags]
 ```
 
 **Flags:**
@@ -75,49 +75,49 @@ globus transfer task list [flags]
 **Example:**
 
 ```bash
-globus transfer task list --limit 10 --filter-status ACTIVE
+globus task list --limit 10 --filter-status ACTIVE
 ```
 
-### globus transfer task show
+### globus task show
 
 Show details for a specific transfer task.
 
 ```bash
-globus transfer task show TASK_ID
+globus task show TASK_ID
 ```
 
-### globus transfer task cancel
+### globus task cancel
 
 Cancel a transfer task.
 
 ```bash
-globus transfer task cancel TASK_ID
+globus task cancel TASK_ID
 ```
 
 ## Endpoint Commands
 
-### globus transfer endpoint list
+### globus endpoint list
 
 List endpoints.
 
 ```bash
-globus transfer endpoint list [flags]
+globus endpoint list [flags]
 ```
 
-### globus transfer endpoint show
+### globus endpoint show
 
 Show details for an endpoint.
 
 ```bash
-globus transfer endpoint show ENDPOINT_ID
+globus endpoint show ENDPOINT_ID
 ```
 
-### globus transfer endpoint search
+### globus endpoint search
 
 Search for endpoints.
 
 ```bash
-globus transfer endpoint search SEARCH_TERMS [flags]
+globus endpoint search SEARCH_TERMS [flags]
 ```
 
 ## See Also


### PR DESCRIPTION
## Phase 3 — flat command structure

Auth and transfer operations are now **top-level commands**, matching the Python
Globus CLI's flat layout instead of nesting everything under service groups.
This closes the single biggest drop-in divergence.

### New invocations (identical to the Python CLI)
```
globus login / logout / whoami / get-identities / device / refresh / tokens
globus ls ENDPOINT:/path
globus mkdir ENDPOINT:/dir
globus rm ENDPOINT:/path
globus transfer SRC_EP:/f DEST_EP:/f      # was: globus transfer cp ...
globus task show|list|cancel|wait
globus endpoint list|show|search
```
`group`, `search`, `flows`, `timer` remain command groups (the Python CLI groups
these too); `compute` stays a Go-only extension group; `config` unchanged.

### Changes
- `cmd/root.go` — `addServiceCommands` wires auth + transfer flat via
  `addAuthCommands(root)` / `addTransferCommands(root)`.
- `cmd/auth.go`, `cmd/transfer.go` — group wrappers replaced with flat wiring.
- `auth.GetIdentitiesCmd()` exposes identity lookup as top-level
  `get-identities`; `transfer`'s `cp` is exposed as the top-level `transfer`
  verb.
- `cmd/root_test.go` — `TestFlatCommandStructure` guards the flat layout.
- Docs: 11 files updated to the flat invocations; `PYTHON_CLI_PARITY.md` notes
  the structural parity.

### ⚠️ Breaking
Nested invocations (`globus auth login`, `globus transfer ls`, …) no longer
work. This is the intended drop-in behavior — the user chose flat-only with no
back-compat aliases.

### Verification
`GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues; binary
smoke-tested (`transfer`/`ls` arg validation, `whoami` not-logged-in path).