### PR TITLE
feat: fill backable command gaps — bookmarks, endpoint admin, task/group actions (Phase 4)

### DIFF
--- a/cmd/group.go
+++ b/cmd/group.go
@@ -43,6 +43,7 @@ Examples:
 	groupCmd.AddCommand(group.JoinCmd)
 	groupCmd.AddCommand(group.LeaveCmd)
 	groupCmd.AddCommand(group.GetMemberCmd())
+	groupCmd.AddCommand(group.PolicyCmd())
 
 	return groupCmd
 }

--- a/cmd/group/join.go
+++ b/cmd/group/join.go
@@ -3,12 +3,16 @@
 package group
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
 	"github.com/spf13/cobra"
 )
 
-var joinRequest bool
+var joinIdentity string
 
 // JoinCmd represents the group join command
 var JoinCmd = &cobra.Command{
@@ -16,28 +20,44 @@ var JoinCmd = &cobra.Command{
 	Short: "Join a Globus group",
 	Long: `Join a Globus group as a member.
 
-For open groups, you will be added immediately. For closed groups,
-use the --request flag to submit a membership request that requires approval.
+The --identity flag specifies the identity ID that joins the group.
 
 Examples:
-  # Join an open group
-  globus group join GROUP_ID
-
-  # Request to join a closed group
-  globus group join GROUP_ID --request`,
+  # Join a group as a specific identity
+  globus group join GROUP_ID --identity IDENTITY_ID`,
 	Args: cobra.ExactArgs(1),
 	RunE: runJoinGroup,
 }
 
 func init() {
-	JoinCmd.Flags().BoolVar(&joinRequest, "request", false, "Request membership (for groups requiring approval)")
+	JoinCmd.Flags().StringVar(&joinIdentity, "identity", "", "Identity ID to join the group as (required)")
+	_ = JoinCmd.MarkFlagRequired("identity")
 }
 
 func runJoinGroup(cmd *cobra.Command, args []string) error {
-	// Note: Join functionality requires direct API integration
-	// The SDK v3.65.0-1 doesn't yet expose a high-level JoinGroup method
-	// This would typically be done via the Groups API /groups/{group_id}/join endpoint
+	groupID := args[0]
 
-	return fmt.Errorf("group join functionality is not yet available in SDK v3.65.0-1\n" +
-		"Please use the Globus web interface to join groups: https://app.globus.org/groups")
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Join the group via a single batch membership action
+	// (POST /groups/{id}); the API has no dedicated join route.
+	_, err = groupsClient.BatchMembershipAction(ctx, groupID, &groups.BatchMembershipActions{
+		Join: []groups.MemberID{{IdentityID: joinIdentity}},
+	})
+	if err != nil {
+		return fmt.Errorf("error joining group: %w", err)
+	}
+
+	// Display success message
+	fmt.Fprintf(os.Stdout, "Successfully joined group %s as identity %s.\n", groupID, joinIdentity)
+
+	return nil
 }

--- a/cmd/group/leave.go
+++ b/cmd/group/leave.go
@@ -3,10 +3,16 @@
 package group
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
 	"github.com/spf13/cobra"
 )
+
+var leaveIdentity string
 
 // LeaveCmd represents the group leave command
 var LeaveCmd = &cobra.Command{
@@ -14,21 +20,47 @@ var LeaveCmd = &cobra.Command{
 	Short: "Leave a Globus group",
 	Long: `Leave a Globus group where you are currently a member.
 
+The --identity flag specifies the identity ID that leaves the group.
+
 Note: If you are the last administrator, you may not be able to leave
 the group without first assigning another administrator.
 
 Examples:
-  # Leave a group
-  globus group leave GROUP_ID`,
+  # Leave a group as a specific identity
+  globus group leave GROUP_ID --identity IDENTITY_ID`,
 	Args: cobra.ExactArgs(1),
 	RunE: runLeaveGroup,
 }
 
-func runLeaveGroup(cmd *cobra.Command, args []string) error {
-	// Note: Leave functionality requires direct API integration
-	// The SDK v3.65.0-1 doesn't yet expose a high-level LeaveGroup method
-	// This can be done by removing yourself as a member using RemoveMember
+func init() {
+	LeaveCmd.Flags().StringVar(&leaveIdentity, "identity", "", "Identity ID to leave the group as (required)")
+	_ = LeaveCmd.MarkFlagRequired("identity")
+}
 
-	return fmt.Errorf("group leave functionality is not yet fully implemented in SDK v3.65.0-1\n" +
-		"To leave a group, have an admin remove you, or use the Globus web interface: https://app.globus.org/groups")
+func runLeaveGroup(cmd *cobra.Command, args []string) error {
+	groupID := args[0]
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Leave the group via a single batch membership action
+	// (POST /groups/{id}); the API has no dedicated leave route.
+	_, err = groupsClient.BatchMembershipAction(ctx, groupID, &groups.BatchMembershipActions{
+		Leave: []groups.MemberID{{IdentityID: leaveIdentity}},
+	})
+	if err != nil {
+		return fmt.Errorf("error leaving group: %w", err)
+	}
+
+	// Display success message
+	fmt.Fprintf(os.Stdout, "Successfully left group %s as identity %s.\n", groupID, leaveIdentity)
+
+	return nil
 }

--- a/cmd/group/member.go
+++ b/cmd/group/member.go
@@ -37,6 +37,10 @@ Examples:
 	memberCmd.AddCommand(MemberAddCmd)
 	memberCmd.AddCommand(MemberRemoveCmd)
 	memberCmd.AddCommand(MemberInviteCmd)
+	memberCmd.AddCommand(memberApproveCmd())
+	memberCmd.AddCommand(memberRejectCmd())
+	memberCmd.AddCommand(memberAcceptCmd())
+	memberCmd.AddCommand(memberDeclineCmd())
 
 	return memberCmd
 }

--- a/cmd/group/member_actions.go
+++ b/cmd/group/member_actions.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package group
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
+	"github.com/spf13/cobra"
+)
+
+// runMemberAction applies a single membership action (built from the given
+// identity ID) to a group via BatchMembershipAction and prints a success
+// message. It centralizes the shared client/context/error handling for the
+// approve/reject/accept/decline commands.
+func runMemberAction(verb string, buildActions func(identityID string) *groups.BatchMembershipActions) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		groupID := args[0]
+		identityID := args[1]
+
+		// Create context with timeout
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Build a v4 Groups client authorized for the current profile.
+		groupsClient, err := getClient(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Apply the membership action via a single batch action
+		// (POST /groups/{id}); the API has no dedicated per-action route.
+		_, err = groupsClient.BatchMembershipAction(ctx, groupID, buildActions(identityID))
+		if err != nil {
+			return fmt.Errorf("error applying %s to member: %w", verb, err)
+		}
+
+		// Display success message
+		fmt.Fprintf(os.Stdout, "Successfully applied %s to identity %s in group %s.\n", verb, identityID, groupID)
+
+		return nil
+	}
+}
+
+// memberApproveCmd approves a pending membership request.
+func memberApproveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "approve GROUP_ID IDENTITY_ID",
+		Short: "Approve a pending membership request",
+		Long: `Approve a pending request to join a Globus group.
+
+Examples:
+  # Approve a membership request
+  globus group member approve GROUP_ID IDENTITY_ID`,
+		Args: cobra.ExactArgs(2),
+		RunE: runMemberAction("approve", func(identityID string) *groups.BatchMembershipActions {
+			return &groups.BatchMembershipActions{Approve: []groups.MemberID{{IdentityID: identityID}}}
+		}),
+	}
+}
+
+// memberRejectCmd rejects a pending membership request.
+func memberRejectCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reject GROUP_ID IDENTITY_ID",
+		Short: "Reject a pending membership request",
+		Long: `Reject a pending request to join a Globus group.
+
+Examples:
+  # Reject a membership request
+  globus group member reject GROUP_ID IDENTITY_ID`,
+		Args: cobra.ExactArgs(2),
+		RunE: runMemberAction("reject", func(identityID string) *groups.BatchMembershipActions {
+			return &groups.BatchMembershipActions{Reject: []groups.MemberID{{IdentityID: identityID}}}
+		}),
+	}
+}
+
+// memberAcceptCmd accepts a pending invitation to join a group.
+func memberAcceptCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "accept GROUP_ID IDENTITY_ID",
+		Short: "Accept a pending group invitation",
+		Long: `Accept a pending invitation to join a Globus group.
+
+Examples:
+  # Accept an invitation
+  globus group member accept GROUP_ID IDENTITY_ID`,
+		Args: cobra.ExactArgs(2),
+		RunE: runMemberAction("accept", func(identityID string) *groups.BatchMembershipActions {
+			return &groups.BatchMembershipActions{Accept: []groups.MemberID{{IdentityID: identityID}}}
+		}),
+	}
+}
+
+// memberDeclineCmd declines a pending invitation to join a group.
+func memberDeclineCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "decline GROUP_ID IDENTITY_ID",
+		Short: "Decline a pending group invitation",
+		Long: `Decline a pending invitation to join a Globus group.
+
+Examples:
+  # Decline an invitation
+  globus group member decline GROUP_ID IDENTITY_ID`,
+		Args: cobra.ExactArgs(2),
+		RunE: runMemberAction("decline", func(identityID string) *groups.BatchMembershipActions {
+			return &groups.BatchMembershipActions{Decline: []groups.MemberID{{IdentityID: identityID}}}
+		}),
+	}
+}

--- a/cmd/group/member_invite.go
+++ b/cmd/group/member_invite.go
@@ -3,25 +3,25 @@
 package group
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
 	"github.com/spf13/cobra"
 )
 
-var (
-	inviteRole              string
-	inviteProvisionIdentity bool
-)
+var inviteRole string
 
 // MemberInviteCmd represents the member invite command
 var MemberInviteCmd = &cobra.Command{
-	Use:   "invite GROUP_ID EMAIL",
+	Use:   "invite GROUP_ID IDENTITY_ID",
 	Short: "Invite a member to join a group",
-	Long: `Invite a user to join a Globus group by email address.
+	Long: `Invite a user to join a Globus group.
 
-The invitee will receive an email invitation to join the group.
-Use --provision-identity to create a Globus identity for users who
-don't have one yet.
+The invitee is identified by their Globus identity ID (not an email
+address); the Groups API requires an identity ID for invitations.
 
 Available roles:
   - member: Basic group membership (default)
@@ -30,29 +30,43 @@ Available roles:
 
 Examples:
   # Invite a basic member
-  globus group member invite GROUP_ID user@example.com
+  globus group member invite GROUP_ID IDENTITY_ID
 
   # Invite with a specific role
-  globus group member invite GROUP_ID user@example.com --role manager
-
-  # Invite and provision identity if needed
-  globus group member invite GROUP_ID user@example.com --provision-identity`,
+  globus group member invite GROUP_ID IDENTITY_ID --role manager`,
 	Args: cobra.ExactArgs(2),
 	RunE: runMemberInvite,
 }
 
 func init() {
 	MemberInviteCmd.Flags().StringVar(&inviteRole, "role", "member", "Role for the invited member (member, manager, admin)")
-	MemberInviteCmd.Flags().BoolVar(&inviteProvisionIdentity, "provision-identity", false, "Provision a Globus identity if the user doesn't have one")
 }
 
 func runMemberInvite(cmd *cobra.Command, args []string) error {
 	groupID := args[0]
+	identityID := args[1]
 
-	// Note: Invite functionality requires direct API integration
-	// The SDK v3.65.0-1 doesn't yet expose a high-level InviteMember method
-	// This would typically be done via the Groups API /groups/{group_id}/invite endpoint
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
-	return fmt.Errorf("member invite functionality is not yet available in SDK v3.65.0-1\n" +
-		"Please use the Globus web interface to invite members: https://app.globus.org/groups/%s", groupID)
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Invite member via a single batch membership action
+	// (POST /groups/{id}); the API has no dedicated invite route.
+	_, err = groupsClient.BatchMembershipAction(ctx, groupID, &groups.BatchMembershipActions{
+		Invite: []groups.MemberWithRole{{IdentityID: identityID, Role: inviteRole}},
+	})
+	if err != nil {
+		return fmt.Errorf("error inviting member: %w", err)
+	}
+
+	// Display success message
+	fmt.Fprintf(os.Stdout, "Successfully invited identity %s to group %s with role '%s'.\n", identityID, groupID, inviteRole)
+
+	return nil
 }

--- a/cmd/group/policies.go
+++ b/cmd/group/policies.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package group
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// PolicyCmd returns the policies command group for managing a group's policy
+// settings (GET/PUT /groups/{id}/policies).
+func PolicyCmd() *cobra.Command {
+	policiesCmd := &cobra.Command{
+		Use:   "policies",
+		Short: "Manage group policies",
+		Long: `Commands for viewing and updating the policy settings of a Globus group.
+
+Group policies control high-assurance enforcement, visibility, join
+requests, and signup fields.
+
+Examples:
+  # Show a group's policies
+  globus group policies show GROUP_ID
+
+  # Update a group's join-request policy
+  globus group policies set GROUP_ID --join-requests`,
+	}
+
+	policiesCmd.AddCommand(policiesShowCmd())
+	policiesCmd.AddCommand(policiesSetCmd())
+
+	return policiesCmd
+}
+
+// policiesShowCmd shows a group's policy settings.
+func policiesShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show GROUP_ID",
+		Short: "Show a group's policy settings",
+		Long: `Show the policy settings for a Globus group.
+
+Examples:
+  # Show group policies
+  globus group policies show GROUP_ID
+
+  # Show with JSON output
+  globus group policies show GROUP_ID --format=json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runPoliciesShow,
+	}
+}
+
+func runPoliciesShow(cmd *cobra.Command, args []string) error {
+	groupID := args[0]
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	policies, err := groupsClient.GetGroupPolicies(ctx, groupID)
+	if err != nil {
+		return fmt.Errorf("error getting group policies: %w", err)
+	}
+
+	format := viper.GetString("format")
+
+	if format == "text" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Group Policies\n")
+		fmt.Fprintf(cmd.OutOrStdout(), "==============\n\n")
+		fmt.Fprintf(cmd.OutOrStdout(), "Is High Assurance:        %v\n", policies.IsHighAssurance)
+		fmt.Fprintf(cmd.OutOrStdout(), "Group Visibility:         %s\n", policies.GroupVisibility)
+		fmt.Fprintf(cmd.OutOrStdout(), "Group Members Visibility: %s\n", policies.GroupMembersVisibility)
+		fmt.Fprintf(cmd.OutOrStdout(), "Join Requests:            %v\n", policies.JoinRequests)
+		fmt.Fprintf(cmd.OutOrStdout(), "Signup Fields:            %s\n", strings.Join(policies.SignupFields, ", "))
+		if policies.AuthenticationAssuranceTimeout != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "Auth Assurance Timeout:   %d\n", *policies.AuthenticationAssuranceTimeout)
+		}
+		return nil
+	}
+
+	// JSON/CSV output emits the policies struct.
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	headers := []string{"IsHighAssurance", "GroupVisibility", "GroupMembersVisibility", "JoinRequests", "SignupFields", "AuthenticationAssuranceTimeout"}
+	if err := formatter.FormatOutput(policies, headers); err != nil {
+		return fmt.Errorf("error formatting output: %w", err)
+	}
+
+	return nil
+}
+
+var (
+	policiesSetHighAssurance     bool
+	policiesSetJoinRequests      bool
+	policiesSetVisibility        string
+	policiesSetMembersVisibility string
+)
+
+// policiesSetCmd updates a group's policy settings. It performs a
+// get-modify-put so that flags left unset preserve their existing values (the
+// underlying PUT replaces the entire policies document).
+func policiesSetCmd() *cobra.Command {
+	setCmd := &cobra.Command{
+		Use:   "set GROUP_ID",
+		Short: "Update a group's policy settings",
+		Long: `Update the policy settings for a Globus group.
+
+Only the flags you provide are changed; unset fields keep their current
+values (the update replaces the whole policies document, so it is applied
+on top of the group's existing policies).
+
+Examples:
+  # Enable join requests
+  globus group policies set GROUP_ID --join-requests
+
+  # Set group visibility to private
+  globus group policies set GROUP_ID --visibility private`,
+		Args: cobra.ExactArgs(1),
+		RunE: runPoliciesSet,
+	}
+
+	setCmd.Flags().BoolVar(&policiesSetHighAssurance, "high-assurance", false, "Enable high-assurance enforcement")
+	setCmd.Flags().BoolVar(&policiesSetJoinRequests, "join-requests", false, "Allow join requests")
+	setCmd.Flags().StringVar(&policiesSetVisibility, "visibility", "", "Group visibility (authenticated, private)")
+	setCmd.Flags().StringVar(&policiesSetMembersVisibility, "members-visibility", "", "Group members visibility (members, managers)")
+
+	return setCmd
+}
+
+func runPoliciesSet(cmd *cobra.Command, args []string) error {
+	groupID := args[0]
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Groups client authorized for the current profile.
+	groupsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Fetch existing policies and apply only the flags the user changed. The
+	// PUT replaces the entire policies document, so we must preserve the
+	// values of flags left unset.
+	policies, err := groupsClient.GetGroupPolicies(ctx, groupID)
+	if err != nil {
+		return fmt.Errorf("error getting current group policies: %w", err)
+	}
+
+	if cmd.Flags().Changed("high-assurance") {
+		policies.IsHighAssurance = policiesSetHighAssurance
+	}
+	if cmd.Flags().Changed("join-requests") {
+		policies.JoinRequests = policiesSetJoinRequests
+	}
+	if cmd.Flags().Changed("visibility") {
+		policies.GroupVisibility = policiesSetVisibility
+	}
+	if cmd.Flags().Changed("members-visibility") {
+		policies.GroupMembersVisibility = policiesSetMembersVisibility
+	}
+
+	if err := groupsClient.SetGroupPolicies(ctx, groupID, policies); err != nil {
+		return fmt.Errorf("error setting group policies: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Successfully updated policies for group %s.\n", groupID)
+
+	return nil
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -77,7 +77,8 @@ func TestFlatCommandStructure(t *testing.T) {
 	// These must exist at the top level (flattened from auth/transfer).
 	wantTopLevel := []string{
 		"login", "logout", "whoami", "get-identities", "device", "refresh", "tokens",
-		"ls", "mkdir", "rm", "transfer", "task", "endpoint",
+		"ls", "mkdir", "rm", "rename", "stat", "delete", "transfer", "task", "endpoint",
+		"bookmark",
 		"group", "search", "flows", "timer", "compute", "config",
 	}
 	for _, name := range wantTopLevel {

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -17,9 +17,13 @@ func addTransferCommands(root *cobra.Command) {
 		transfer.LsCmd(),
 		transfer.MkdirCmd(),
 		transfer.RmCmd(),
+		transfer.RenameCmd(),
+		transfer.StatCmd(),
+		transfer.DeleteCmd(),
 		transfer.CpCmd(), // exposed as the top-level `transfer` verb
 		transfer.TaskCmd(),
 		transfer.EndpointCmd(),
+		transfer.BookmarkCmd(),
 		transfer.TunnelCmd(),
 		transfer.StreamAccessPointCmd(),
 	)

--- a/cmd/transfer/bookmark.go
+++ b/cmd/transfer/bookmark.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
+)
+
+// BookmarkCmd returns the bookmark command
+func BookmarkCmd() *cobra.Command {
+	// bookmarkCmd represents the bookmark command
+	bookmarkCmd := &cobra.Command{
+		Use:   "bookmark",
+		Short: "Commands for managing Globus bookmarks",
+		Long: `Commands for managing Globus Transfer bookmarks including listing,
+creating, renaming, and deleting saved endpoint/path bookmarks.`,
+	}
+
+	// Add bookmark subcommands
+	bookmarkCmd.AddCommand(
+		bookmarkListCmd(),
+		bookmarkShowCmd(),
+		bookmarkCreateCmd(),
+		bookmarkRenameCmd(),
+		bookmarkDeleteCmd(),
+	)
+
+	return bookmarkCmd
+}
+
+// Options for bookmark creation
+var (
+	bookmarkName       string
+	bookmarkCollection string
+	bookmarkPath       string
+)
+
+// bookmarkListCmd returns the bookmark list command
+func bookmarkListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List Globus bookmarks",
+		Long: `List Globus Transfer bookmarks belonging to the current user.
+
+This command lists all saved bookmarks, each referencing a collection
+and a path within that collection.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listBookmarks(cmd)
+		},
+	}
+}
+
+// bookmarkShowCmd returns the bookmark show command
+func bookmarkShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show BOOKMARK_ID",
+		Short: "Show bookmark details",
+		Long: `Show detailed information about a specific Globus bookmark.
+
+This command displays all available details about the specified bookmark,
+including the collection and path it references.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showBookmark(cmd, args[0])
+		},
+	}
+}
+
+// bookmarkCreateCmd returns the bookmark create command
+func bookmarkCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Globus bookmark",
+		Long: `Create a Globus Transfer bookmark referencing a collection and path.
+
+A bookmark saves an endpoint/collection UUID together with a path so it can
+be referenced later by name.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return createBookmark(cmd)
+		},
+	}
+
+	// Add flags for creation
+	cmd.Flags().StringVar(&bookmarkName, "name", "", "Name for the bookmark (required)")
+	cmd.Flags().StringVar(&bookmarkCollection, "collection", "", "Endpoint/collection UUID (required)")
+	cmd.Flags().StringVar(&bookmarkPath, "path", "", "Path within the collection (required)")
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("collection")
+	_ = cmd.MarkFlagRequired("path")
+
+	return cmd
+}
+
+// bookmarkRenameCmd returns the bookmark rename command
+func bookmarkRenameCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rename BOOKMARK_ID NEW_NAME",
+		Short: "Rename a Globus bookmark",
+		Long: `Rename a Globus Transfer bookmark.
+
+This command changes the display name of the specified bookmark.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return renameBookmark(cmd, args[0], args[1])
+		},
+	}
+}
+
+// bookmarkDeleteCmd returns the bookmark delete command
+func bookmarkDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete BOOKMARK_ID",
+		Short: "Delete a Globus bookmark",
+		Long: `Delete a Globus Transfer bookmark.
+
+This command permanently removes the specified bookmark.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deleteBookmark(cmd, args[0])
+		},
+	}
+}
+
+// listBookmarks lists Globus bookmarks
+func listBookmarks(cmd *cobra.Command) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get the bookmarks
+	resp, err := transferClient.ListBookmarks(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list bookmarks: %w", err)
+	}
+
+	// Route all formats through the shared formatter so -F (text/json/unix) and
+	// --jmespath/--jq work uniformly. For JSON/JMESPath, emit the raw bookmark
+	// documents; for text/unix, a projected row set.
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+
+	if formatter.Format == output.FormatJSON {
+		return formatter.FormatOutput(resp.Bookmarks, nil)
+	}
+
+	type bookmarkRow struct {
+		ID           string
+		Name         string
+		CollectionID string
+		Path         string
+	}
+	rows := make([]bookmarkRow, 0, len(resp.Bookmarks))
+	for _, b := range resp.Bookmarks {
+		rows = append(rows, bookmarkRow{
+			ID: b.ID, Name: b.Name, CollectionID: b.CollectionID, Path: b.Path,
+		})
+	}
+	return formatter.FormatOutput(rows, []string{"ID", "Name", "CollectionID", "Path"})
+}
+
+// showBookmark shows details for a specific bookmark
+func showBookmark(cmd *cobra.Command, bookmarkID string) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get the bookmark
+	bookmark, err := transferClient.GetBookmark(ctx, bookmarkID)
+	if err != nil {
+		return fmt.Errorf("failed to get bookmark: %w", err)
+	}
+
+	// For json/unix or a --jmespath/--jq expression, route through the shared
+	// formatter (emitting the raw bookmark document). Otherwise render the text
+	// detail view below.
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(bookmark, nil)
+	}
+
+	{
+		// Output as text
+		fmt.Println("Bookmark Details:")
+		fmt.Printf("  ID:             %s\n", bookmark.ID)
+		fmt.Printf("  Name:           %s\n", bookmark.Name)
+		fmt.Printf("  CollectionID:   %s\n", bookmark.CollectionID)
+		fmt.Printf("  Path:           %s\n", bookmark.Path)
+	}
+
+	return nil
+}
+
+// createBookmark creates a Globus bookmark
+func createBookmark(cmd *cobra.Command) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Create the bookmark
+	bookmark, err := transferClient.CreateBookmark(ctx, &transfer.BookmarkCreate{
+		Collection: bookmarkCollection,
+		Name:       bookmarkName,
+		Path:       bookmarkPath,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create bookmark: %w", err)
+	}
+
+	fmt.Printf("Created bookmark %s (%s)\n", bookmark.ID, bookmark.Name)
+	return nil
+}
+
+// renameBookmark renames a Globus bookmark
+func renameBookmark(cmd *cobra.Command, bookmarkID, newName string) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Update the bookmark name
+	if _, err := transferClient.UpdateBookmark(ctx, bookmarkID, &transfer.BookmarkUpdate{Name: &newName}); err != nil {
+		return fmt.Errorf("failed to rename bookmark: %w", err)
+	}
+
+	fmt.Printf("Renamed bookmark %s to %s\n", bookmarkID, newName)
+	return nil
+}
+
+// deleteBookmark deletes a Globus bookmark
+func deleteBookmark(cmd *cobra.Command, bookmarkID string) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Delete the bookmark
+	if err := transferClient.DeleteBookmark(ctx, bookmarkID); err != nil {
+		return fmt.Errorf("failed to delete bookmark: %w", err)
+	}
+
+	fmt.Printf("Deleted bookmark %s\n", bookmarkID)
+	return nil
+}

--- a/cmd/transfer/delete.go
+++ b/cmd/transfer/delete.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
+)
+
+var (
+	deleteRecursive     bool
+	deleteIgnoreMissing bool
+)
+
+// DeleteCmd returns the delete command
+func DeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete ENDPOINT_ID:PATH",
+		Short: "Submit a delete task for a path on an endpoint",
+		Long: `Submit a delete task for a file or directory on a Globus endpoint.
+
+This is the task-based delete operation. If --recursive is specified, it will
+delete directories and their contents. If --ignore-missing is specified, the
+task will not error when the path does not exist.
+
+Examples:
+  globus transfer delete ddb59aef-6d04-11e5-ba46-22000b92c6ec:/path/to/file
+  globus transfer delete --recursive ddb59aef-6d04-11e5-ba46-22000b92c6ec:/path/to/directory`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Parse endpoint ID and path
+			endpointID, path := parseEndpointAndPath(args[0])
+
+			if path == "/" {
+				return fmt.Errorf("path must be specified for delete command")
+			}
+
+			return submitDeleteTask(cmd, endpointID, path)
+		},
+	}
+
+	// Add flags
+	cmd.Flags().BoolVar(&deleteRecursive, "recursive", false, "Delete directories and their contents recursively")
+	cmd.Flags().BoolVar(&deleteIgnoreMissing, "ignore-missing", false, "Do not error if the path does not exist")
+
+	return cmd
+}
+
+// submitDeleteTask submits a delete task for a path on an endpoint
+func submitDeleteTask(cmd *cobra.Command, endpointID, path string) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// The v4 SDK requires a submission ID minted from the service and carries
+	// recursion/ignore-missing on the Delete request itself.
+	submissionID, err := transferClient.GetSubmissionID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get submission ID: %w", err)
+	}
+
+	deleteRequest := &transfer.Delete{
+		DATA_TYPE:     "delete",
+		SubmissionID:  submissionID,
+		Endpoint:      endpointID,
+		Recursive:     deleteRecursive,
+		IgnoreMissing: deleteIgnoreMissing,
+		Items: []transfer.DeleteItem{
+			{DATA_TYPE: "delete_item", Path: path},
+		},
+	}
+
+	taskResponse, err := transferClient.SubmitDelete(ctx, deleteRequest)
+	if err != nil {
+		return fmt.Errorf("failed to submit delete task: %w", err)
+	}
+
+	fmt.Printf("Delete task submitted. Task ID: %s\n", taskResponse.TaskID)
+	return nil
+}

--- a/cmd/transfer/endpoint.go
+++ b/cmd/transfer/endpoint.go
@@ -29,6 +29,10 @@ searching, and displaying endpoint details.`,
 		endpointListCmd(),
 		endpointShowCmd(),
 		endpointSearchCmd(),
+		endpointUpdateCmd(),
+		endpointDeleteCmd(),
+		endpointRoleCmd(),
+		endpointPermissionCmd(),
 	)
 
 	return endpointCmd

--- a/cmd/transfer/endpoint_admin.go
+++ b/cmd/transfer/endpoint_admin.go
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+)
+
+// endpointUpdateCmd returns the "endpoint update" command, which patches an
+// endpoint document with only the fields the user explicitly set.
+func endpointUpdateCmd() *cobra.Command {
+	var (
+		displayName  string
+		description  string
+		organization string
+		contactEmail string
+		keywords     []string
+		public       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update ENDPOINT_ID",
+		Short: "Update a Globus endpoint",
+		Long: `Update mutable fields on a Globus endpoint.
+
+Only the flags you provide are sent; unset fields are left unchanged.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			doc := map[string]interface{}{"DATA_TYPE": "endpoint"}
+			if cmd.Flags().Changed("display-name") {
+				doc["display_name"] = displayName
+			}
+			if cmd.Flags().Changed("description") {
+				doc["description"] = description
+			}
+			if cmd.Flags().Changed("organization") {
+				doc["organization"] = organization
+			}
+			if cmd.Flags().Changed("contact-email") {
+				doc["contact_email"] = contactEmail
+			}
+			if cmd.Flags().Changed("keywords") {
+				doc["keywords"] = keywords
+			}
+			if cmd.Flags().Changed("public") {
+				doc["public"] = public
+			}
+
+			resp, err := client.UpdateEndpoint(ctx, args[0], doc)
+			if err != nil {
+				return fmt.Errorf("failed to update endpoint: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Endpoint %s updated.\n", args[0])
+			printResponseCodeMessage(cmd, resp)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&displayName, "display-name", "", "New display name")
+	cmd.Flags().StringVar(&description, "description", "", "New description")
+	cmd.Flags().StringVar(&organization, "organization", "", "New organization")
+	cmd.Flags().StringVar(&contactEmail, "contact-email", "", "New contact email")
+	cmd.Flags().StringSliceVar(&keywords, "keywords", nil, "Keywords for the endpoint")
+	cmd.Flags().BoolVar(&public, "public", false, "Whether the endpoint is public")
+
+	return cmd
+}
+
+// endpointDeleteCmd returns the "endpoint delete" command.
+func endpointDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete ENDPOINT_ID",
+		Short: "Delete a Globus endpoint",
+		Long:  `Delete a Globus endpoint by ID.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.DeleteEndpoint(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to delete endpoint: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Endpoint %s deleted.\n", args[0])
+			printResponseCodeMessage(cmd, resp)
+			return nil
+		},
+	}
+}
+
+// endpointRoleCmd returns the "endpoint role" command group for managing
+// endpoint role assignments.
+func endpointRoleCmd() *cobra.Command {
+	roleCmd := &cobra.Command{
+		Use:   "role",
+		Short: "Manage endpoint role assignments",
+		Long:  `List, show, create, and delete role assignments on a Globus endpoint.`,
+	}
+
+	roleCmd.AddCommand(
+		endpointRoleListCmd(),
+		endpointRoleShowCmd(),
+		endpointRoleCreateCmd(),
+		endpointRoleDeleteCmd(),
+	)
+
+	return roleCmd
+}
+
+func endpointRoleListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list ENDPOINT_ID",
+		Short: "List role assignments for an endpoint",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointRoleList(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to list endpoint roles: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointRoleShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show ENDPOINT_ID ROLE_ID",
+		Short: "Show a role assignment for an endpoint",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.GetEndpointRole(ctx, args[0], args[1])
+			if err != nil {
+				return fmt.Errorf("failed to get endpoint role: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointRoleCreateCmd() *cobra.Command {
+	var (
+		principal     string
+		principalType string
+		role          string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create ENDPOINT_ID",
+		Short: "Create a role assignment on an endpoint",
+		Long: `Assign a role to a principal on a Globus endpoint.
+
+The --role value is one of administrator, access_manager, activity_manager,
+or activity_monitor.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			doc := map[string]interface{}{
+				"DATA_TYPE":      "role",
+				"principal_type": principalType,
+				"principal":      principal,
+				"role":           role,
+			}
+
+			resp, err := client.AddEndpointRole(ctx, args[0], doc)
+			if err != nil {
+				return fmt.Errorf("failed to create endpoint role: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&principal, "principal", "", "Principal (identity or group ID) to assign the role to")
+	cmd.Flags().StringVar(&principalType, "principal-type", "identity", "Principal type (identity or group)")
+	cmd.Flags().StringVar(&role, "role", "", "Role name (administrator, access_manager, activity_manager, activity_monitor)")
+	_ = cmd.MarkFlagRequired("principal")
+	_ = cmd.MarkFlagRequired("role")
+
+	return cmd
+}
+
+func endpointRoleDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete ENDPOINT_ID ROLE_ID",
+		Short: "Delete a role assignment from an endpoint",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.DeleteEndpointRole(ctx, args[0], args[1])
+			if err != nil {
+				return fmt.Errorf("failed to delete endpoint role: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Role %s deleted from endpoint %s.\n", args[1], args[0])
+			printResponseCodeMessage(cmd, resp)
+			return nil
+		},
+	}
+}
+
+// endpointPermissionCmd returns the "endpoint permission" command group for
+// managing endpoint access rules (ACLs).
+func endpointPermissionCmd() *cobra.Command {
+	permCmd := &cobra.Command{
+		Use:   "permission",
+		Short: "Manage endpoint access rules (ACLs)",
+		Long:  `List, show, create, update, and delete access rules on a Globus endpoint.`,
+	}
+
+	permCmd.AddCommand(
+		endpointPermissionListCmd(),
+		endpointPermissionShowCmd(),
+		endpointPermissionCreateCmd(),
+		endpointPermissionUpdateCmd(),
+		endpointPermissionDeleteCmd(),
+	)
+
+	return permCmd
+}
+
+func endpointPermissionListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list ENDPOINT_ID",
+		Short: "List access rules for an endpoint",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointACLList(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to list endpoint access rules: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointPermissionShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show ENDPOINT_ID RULE_ID",
+		Short: "Show an access rule for an endpoint",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.GetEndpointACLRule(ctx, args[0], args[1])
+			if err != nil {
+				return fmt.Errorf("failed to get endpoint access rule: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointPermissionCreateCmd() *cobra.Command {
+	var (
+		permissions   string
+		principal     string
+		principalType string
+		path          string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create ENDPOINT_ID",
+		Short: "Create an access rule on an endpoint",
+		Long: `Create an access rule (ACL) granting permissions on a path.
+
+The --principal-type value is one of identity, group,
+all_authenticated_users, or anonymous.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			doc := map[string]interface{}{
+				"DATA_TYPE":      "access",
+				"principal_type": principalType,
+				"principal":      principal,
+				"path":           path,
+				"permissions":    permissions,
+			}
+
+			resp, err := client.AddEndpointACLRule(ctx, args[0], doc)
+			if err != nil {
+				return fmt.Errorf("failed to create endpoint access rule: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&permissions, "permissions", "", `Permissions to grant (e.g. "r" or "rw")`)
+	cmd.Flags().StringVar(&principal, "principal", "", "Principal (identity or group ID) to grant access to")
+	cmd.Flags().StringVar(&principalType, "principal-type", "identity", "Principal type (identity, group, all_authenticated_users, anonymous)")
+	cmd.Flags().StringVar(&path, "path", "", "Path the rule applies to")
+	_ = cmd.MarkFlagRequired("permissions")
+	_ = cmd.MarkFlagRequired("path")
+
+	return cmd
+}
+
+func endpointPermissionUpdateCmd() *cobra.Command {
+	var permissions string
+
+	cmd := &cobra.Command{
+		Use:   "update ENDPOINT_ID RULE_ID",
+		Short: "Update an access rule on an endpoint",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			doc := map[string]interface{}{
+				"DATA_TYPE":   "access",
+				"permissions": permissions,
+			}
+
+			resp, err := client.UpdateEndpointACLRule(ctx, args[0], args[1], doc)
+			if err != nil {
+				return fmt.Errorf("failed to update endpoint access rule: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&permissions, "permissions", "", `New permissions (e.g. "r" or "rw")`)
+	_ = cmd.MarkFlagRequired("permissions")
+
+	return cmd
+}
+
+func endpointPermissionDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete ENDPOINT_ID RULE_ID",
+		Short: "Delete an access rule from an endpoint",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.DeleteEndpointACLRule(ctx, args[0], args[1])
+			if err != nil {
+				return fmt.Errorf("failed to delete endpoint access rule: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Access rule %s deleted from endpoint %s.\n", args[1], args[0])
+			printResponseCodeMessage(cmd, resp)
+			return nil
+		},
+	}
+}
+
+// formatGenericResponse routes a GenericResponse (map[string]interface{})
+// through the shared formatter so -F (text/json/unix) and --jmespath/--jq
+// work uniformly. For text/unix, the whole map is emitted.
+func formatGenericResponse(cmd *cobra.Command, resp map[string]interface{}) error {
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	return formatter.FormatOutput(resp, nil)
+}
+
+// printResponseCodeMessage prints the "code" and "message" fields of a Transfer
+// GenericResponse when present, for success/status feedback on mutations.
+func printResponseCodeMessage(cmd *cobra.Command, resp map[string]interface{}) {
+	if resp == nil {
+		return
+	}
+	if code, ok := resp["code"].(string); ok && code != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "  Code:    %s\n", code)
+	}
+	if msg, ok := resp["message"].(string); ok && msg != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "  Message: %s\n", msg)
+	}
+}

--- a/cmd/transfer/rename.go
+++ b/cmd/transfer/rename.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// RenameCmd returns the rename command
+func RenameCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rename ENDPOINT_ID:OLD_PATH NEW_PATH",
+		Short: "Rename a file or directory on an endpoint",
+		Long: `Rename a file or directory on a Globus endpoint.
+
+This command renames a path on the specified Globus endpoint. The first
+argument is the endpoint and current path; the second argument is the new
+path on the same endpoint.
+
+Examples:
+  globus transfer rename ddb59aef-6d04-11e5-ba46-22000b92c6ec:/path/old.txt /path/new.txt
+  globus transfer rename ddb59aef-6d04-11e5-ba46-22000b92c6ec:/dir/old /dir/new`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Parse endpoint ID and the current path; the second arg is the
+			// new path on the same endpoint.
+			endpointID, oldPath := parseEndpointAndPath(args[0])
+			newPath := args[1]
+
+			if oldPath == "/" {
+				return fmt.Errorf("a source path must be specified for rename command")
+			}
+
+			return renamePath(cmd, endpointID, oldPath, newPath)
+		},
+	}
+
+	return cmd
+}
+
+// renamePath renames a file or directory on an endpoint
+func renamePath(cmd *cobra.Command, endpointID, oldPath, newPath string) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Rename the path. The v4 SDK takes endpoint/old-path/new-path/local-user
+	// positionally; local-user is optional (pass "").
+	if _, err := transferClient.Rename(ctx, endpointID, oldPath, newPath, ""); err != nil {
+		return fmt.Errorf("failed to rename: %w", err)
+	}
+
+	fmt.Printf("Successfully renamed %s:%s to %s\n", endpointID, oldPath, newPath)
+	return nil
+}

--- a/cmd/transfer/stat.go
+++ b/cmd/transfer/stat.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+)
+
+// StatCmd returns the stat command
+func StatCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stat ENDPOINT_ID:PATH",
+		Short: "Show metadata for a single path on an endpoint",
+		Long: `Show metadata for a single file or directory on a Globus endpoint.
+
+This command stats a single path and reports its name, type, size, last
+modified time, and permissions.
+
+Examples:
+  globus transfer stat ddb59aef-6d04-11e5-ba46-22000b92c6ec:/path/to/file`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Parse endpoint ID and path
+			endpointID, path := parseEndpointAndPath(args[0])
+
+			if path == "/" {
+				return fmt.Errorf("path must be specified for stat command")
+			}
+
+			return statPath(cmd, endpointID, path)
+		},
+	}
+
+	return cmd
+}
+
+// statPath stats a single path on an endpoint
+func statPath(cmd *cobra.Command, endpointID, path string) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Stat the path. GenericResponse is a map[string]interface{} passthrough.
+	resp, err := transferClient.OperationStat(ctx, endpointID, path, "")
+	if err != nil {
+		return fmt.Errorf("failed to stat path: %w", err)
+	}
+
+	// For json/unix or a --jmespath/--jq expression, route through the shared
+	// formatter (raw stat document). Otherwise render the text detail view.
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(resp, nil)
+	}
+
+	// Output as text, guarding for keys that may be absent.
+	fmt.Println("Path Details:")
+	if v, ok := resp["name"]; ok {
+		fmt.Printf("  Name:          %v\n", v)
+	}
+	if v, ok := resp["type"]; ok {
+		fmt.Printf("  Type:          %v\n", v)
+	}
+	if v, ok := resp["size"]; ok {
+		fmt.Printf("  Size:          %v\n", v)
+	}
+	if v, ok := resp["last_modified"]; ok {
+		fmt.Printf("  Last Modified: %v\n", v)
+	}
+	if v, ok := resp["permissions"]; ok {
+		fmt.Printf("  Permissions:   %v\n", v)
+	}
+
+	return nil
+}

--- a/cmd/transfer/task.go
+++ b/cmd/transfer/task.go
@@ -37,6 +37,9 @@ showing details, canceling, and waiting for completion.`,
 		taskShowCmd(),
 		taskCancelCmd(),
 		taskWaitCmd(),
+		taskEventListCmd(),
+		taskPauseInfoCmd(),
+		taskUpdateCmd(),
 	)
 
 	return taskCmd

--- a/cmd/transfer/task_extra.go
+++ b/cmd/transfer/task_extra.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
+)
+
+var (
+	taskUpdateLabel    string
+	taskUpdateDeadline string
+)
+
+// TaskExtraSubcommands returns the additional task subcommands (event-list,
+// pause-info, update) so the task group can attach them.
+func TaskExtraSubcommands() []*cobra.Command {
+	return []*cobra.Command{
+		taskEventListCmd(),
+		taskPauseInfoCmd(),
+		taskUpdateCmd(),
+	}
+}
+
+// taskEventListCmd returns the task event-list command
+func taskEventListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "event-list TASK_ID",
+		Short: "List events for a Globus Transfer task",
+		Long: `List events for a specific Globus Transfer task.
+
+This command displays the event log for a transfer task, including
+timestamps, event codes, and descriptions.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listTaskEvents(cmd, args[0])
+		},
+	}
+
+	// Add flags
+	cmd.Flags().IntVar(&limit, "limit", 25, "Maximum number of events to return")
+
+	return cmd
+}
+
+// taskPauseInfoCmd returns the task pause-info command
+func taskPauseInfoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "pause-info TASK_ID",
+		Short: "Show why a Globus Transfer task is paused",
+		Long: `Show pause information for a specific Globus Transfer task.
+
+This command reports the rules and reasons a transfer task is currently
+paused, if any.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showTaskPauseInfo(cmd, args[0])
+		},
+	}
+}
+
+// taskUpdateCmd returns the task update command
+func taskUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update TASK_ID",
+		Short: "Update a Globus Transfer task's label or deadline",
+		Long: `Update a Globus Transfer task's label and/or deadline.
+
+This command updates the mutable fields of a transfer task. Only the flags
+you set are sent to the service.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return updateTask(cmd, args[0])
+		},
+	}
+
+	// Add flags
+	cmd.Flags().StringVar(&taskUpdateLabel, "label", "", "New label for the task")
+	cmd.Flags().StringVar(&taskUpdateDeadline, "deadline", "", "New deadline for the task")
+
+	return cmd
+}
+
+// listTaskEvents lists events for a task
+func listTaskEvents(cmd *cobra.Command, taskID string) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := transferClient.TaskEventList(ctx, taskID, &transfer.ListTaskEventsOptions{Limit: limit})
+	if err != nil {
+		return fmt.Errorf("failed to list task events: %w", err)
+	}
+
+	// For json/unix or a --jmespath/--jq expression, route through the shared
+	// formatter (raw event documents). Otherwise render the text view.
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(resp.Data, nil)
+	}
+
+	fmt.Printf("Events for task %s:\n", taskID)
+	for _, event := range resp.Data {
+		fmt.Println()
+		if v, ok := event["time"]; ok {
+			fmt.Printf("  Time:        %v\n", v)
+		}
+		if v, ok := event["code"]; ok {
+			fmt.Printf("  Code:        %v\n", v)
+		}
+		if v, ok := event["description"]; ok {
+			fmt.Printf("  Description: %v\n", v)
+		}
+		if v, ok := event["is_error"]; ok {
+			fmt.Printf("  Is Error:    %v\n", v)
+		}
+	}
+
+	return nil
+}
+
+// showTaskPauseInfo shows pause information for a task
+func showTaskPauseInfo(cmd *cobra.Command, taskID string) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := transferClient.TaskPauseInfo(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("failed to get task pause info: %w", err)
+	}
+
+	// Route through the shared formatter (GenericResponse is a map).
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	return formatter.FormatOutput(resp, nil)
+}
+
+// updateTask updates a task's label and/or deadline
+func updateTask(cmd *cobra.Command, taskID string) error {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build a v4 Transfer client authorized for the current profile.
+	transferClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Build the update document with only the fields that were set.
+	doc := map[string]interface{}{"DATA_TYPE": "task"}
+	if cmd.Flags().Changed("label") {
+		doc["label"] = taskUpdateLabel
+	}
+	if cmd.Flags().Changed("deadline") {
+		doc["deadline"] = taskUpdateDeadline
+	}
+
+	if _, err := transferClient.UpdateTask(ctx, taskID, doc); err != nil {
+		return fmt.Errorf("failed to update task: %w", err)
+	}
+
+	fmt.Printf("Successfully updated task %s\n", taskID)
+	return nil
+}

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -52,23 +52,23 @@ device-code flow and `identities lookup` performs a real `GetIdentities` call
 
 | Area | Python CLI | Go CLI | Status |
 |------|-----------|--------|--------|
-| Login / logout / whoami | ✅ | ✅ (`auth login/logout/whoami`) | Covered |
-| Identity lookup | `get-identities` | ✅ (`auth identities lookup`) | Covered |
-| Transfer submit / ls / mkdir / rename / rm / stat | ✅ | Partial — `cp`, `ls`, `mkdir`, `rm`; **no `rename`, no `stat`** | Gap: rename, stat |
-| Tasks (show/list/cancel/wait/event-list/pause-info/update) | ✅ (8) | Partial — show/list/cancel/wait; **no event-list, pause-info, update, generate-submission-id** | Gap |
-| Endpoint search / show / update / delete | ✅ | Partial — search/show/list; **no update/delete** | Gap |
-| Endpoint roles | ✅ (create/delete/list/show) | ❌ none | Gap |
-| Endpoint permissions (ACLs) | ✅ (5) | ❌ none | Gap |
-| Bookmarks | ✅ (5) | ❌ none | Gap |
-| Collections / GCS management | ✅ (`collection`, `gcs`, 32 cmds) | ❌ none | Gap (no SDK support) |
+| Login / logout / whoami | ✅ | ✅ (`login`/`logout`/`whoami`) | Covered |
+| Identity lookup | `get-identities` | ✅ (`get-identities`) | Covered |
+| Transfer submit / ls / mkdir / rename / rm / stat | ✅ | ✅ — `transfer`, `ls`, `mkdir`, `rm`, `rename`, `stat`, `delete` | Covered (Phase 4) |
+| Tasks (show/list/cancel/wait/event-list/pause-info/update) | ✅ (8) | ✅ — show/list/cancel/wait/event-list/pause-info/update | Covered (Phase 4) |
+| Endpoint search / show / update / delete | ✅ | ✅ — search/show/list/update/delete | Covered (Phase 4) |
+| Endpoint roles | ✅ (create/delete/list/show) | ✅ (`endpoint role list/show/create/delete`) | Covered (Phase 4) |
+| Endpoint permissions (ACLs) | ✅ (5) | ✅ (`endpoint permission list/show/create/update/delete`) | Covered (Phase 4) |
+| Bookmarks | ✅ (5) | ✅ (`bookmark list/show/create/rename/delete`) | Covered (Phase 4) |
+| Collections / GCS management | ✅ (`collection`, `gcs`, 32 cmds) | ❌ none | Gap (Phase 5 — v4 gcs service) |
 | GCP (Connect Personal) | ✅ (6) | ❌ none | Gap (no SDK support) |
-| Streams / tunnels | ✅ (8) | Stubs (report "unavailable") | Gap (not in v3 SDK) |
+| Streams / tunnels | ✅ (8) | Stubs (report "unavailable") | Gap (v4 transfer tunnels exist; Phase 5) |
 | Search (index/query/ingest/task/role/subject) | ✅ (14) | ✅ comparable | Covered |
-| Groups (member/role/policy/invite/join/leave) | ✅ (19) | Partial — create/delete/list/show/update, member add/invite/list/remove, join/leave; **no group role commands** | Mostly covered |
+| Groups (member/role/policy/invite/join/leave) | ✅ (19) | ✅ — create/delete/list/show/update, member add/invite/list/remove/accept/decline/approve/reject, join/leave, `policies show/set` | Covered (Phase 4) |
 | Flows (create/run/list/show/update/validate/logs) | ✅ (17) | ✅ comparable | Covered |
 | Timers | ✅ (7) | ✅ (create/list/show/pause/resume/delete) | Covered |
-| `api` raw passthrough | ✅ (7 services) | ❌ none | Gap |
-| `session` (consent/show/update) | ✅ (3) | ❌ none | Gap |
+| `api` raw passthrough | ✅ (7 services) | ❌ none | Gap (Phase 5) |
+| `session` (consent/show/update) | ✅ (3) | ❌ none | Gap — needs reauth/session-boundary support not in the v4 SDK (only `GetConsents`) |
 | Compute | ❌ (not in Python CLI) | ✅ (endpoint/function/task) | Go-only extension |
 
 ## Gap classification
@@ -77,24 +77,25 @@ Two kinds of gap, important to distinguish:
 
 ### A. CLI gaps the Go SDK already supports (exposing them is CLI-only work)
 
-The v3 SDK parity audit added the wire methods for most of these; the CLI simply
-hasn't wired up commands yet:
+**Phase 4 wired up most of these** — now covered: bookmarks
+(`bookmark list/show/create/rename/delete`), endpoint roles
+(`endpoint role list/show/create/delete`), endpoint ACLs
+(`endpoint permission list/show/create/update/delete`), endpoint
+`update`/`delete`, transfer `rename`/`stat`/`delete`, task
+`event-list`/`pause-info`/`update`, and group membership actions
+(`member accept/decline/approve/reject`, real `join`/`leave`/`invite`) plus
+`group policies show/set`.
 
-- **Bookmarks** — SDK: `BookmarkList`/`CreateBookmark`/`GetBookmark`/
-  `UpdateBookmark`/`DeleteBookmark`.
-- **Endpoint roles** — SDK: `EndpointRoleList`/`AddEndpointRole`/
-  `GetEndpointRole`/`DeleteEndpointRole`.
-- **Endpoint ACLs / permissions** — SDK: `EndpointACLList`/`GetEndpointACLRule`/
-  `AddEndpointACLRule`/`UpdateEndpointACLRule`/`DeleteEndpointACLRule`.
-- **Endpoint update/delete, set-subscription-id, shared-endpoint list** — SDK:
-  `UpdateEndpoint`/`DeleteEndpoint`/`SetSubscriptionID`/`MySharedEndpointList`/
-  `GetSharedEndpointList`.
-- **Transfer `stat`** — SDK: `OperationStat`. **`rename`** — SDK: `Rename`.
-- **Task `event-list`/`pause-info`/`update`** — SDK: `TaskEventList`/
-  `TaskPauseInfo`/`UpdateTask` (+ `TaskSuccessfulTransfers`/`TaskSkippedErrors`).
-- **Endpoint-manager admin surface** — SDK: full `EndpointManager*` family.
-- **Group roles**, **session/consents** — SDK: groups membership actions and
-  auth `GetConsents`/`GetIdentities` exist.
+Still available in the SDK but not yet wired:
+
+- **Endpoint `set-subscription-id`, shared-endpoint list** — SDK:
+  `SetSubscriptionID`/`MySharedEndpointList`/`GetSharedEndpointList`.
+- **Endpoint-manager admin surface** — SDK: full `EndpointManager*` family
+  (monitored endpoints, admin task list/cancel/pause, pause rules).
+- **`session` show/update/consent** — the Python CLI's session commands drive a
+  high-assurance **reauthentication / session-boundary** flow. The v4 Go SDK
+  exposes `GetConsents` but no reauth/session-update endpoint, so a faithful
+  `session` is deferred pending SDK support (see Phase 6 / SDK work).
 
 ### B. Gaps with no v3 SDK support (need SDK work first, or are out of scope)
 
@@ -118,10 +119,16 @@ or functions server-side — those require the Globus Compute serialization SDK)
 ## Summary
 
 The Go CLI covers the **core data-management workflows** (transfer, search,
-groups, flows, timers, auth) at rough parity with the Python CLI's most-used
-commands, plus a compute extension. The material gaps are:
+groups, flows, timers, auth) at parity with the Python CLI's most-used commands,
+plus a compute extension. After Phase 4, endpoint administration (roles,
+ACLs/permissions, update/delete), bookmarks, transfer `rename`/`stat`/`delete`,
+task `event-list`/`pause-info`/`update`, and the full group membership + policy
+surface are all wired. The remaining gaps are:
 
-1. **Endpoint administration** (roles, ACLs/permissions, update/delete) and
-   **bookmarks** — all SDK-supported; CLI wiring is the remaining work.
-2. **GCS/collections and GCP** — larger, need a v4-gcs path or are out of scope.
-3. **`api` passthrough** and **`session`** — convenience features.
+1. **GCS/collections** (`collection`, `gcs`) — Phase 5, via the v4 `gcs` service.
+2. **`api` raw passthrough** — Phase 5, a thin HTTP wrapper.
+3. **Streams/tunnels** — v4 transfer client has the methods; Phase 5 can replace
+   the "unavailable" stubs.
+4. **`session`** — needs reauth/session-boundary SDK support not yet available.
+5. **GCP (Connect Personal)** — local-agent management; not an SDK API
+   (out of scope).


### PR DESCRIPTION
## Phase 4 — fill the v4-SDK-backed command gaps

Wires up the commands the parity doc flagged as Category-A gaps (SDK-backed,
just needed CLI wiring). Most of `docs/PYTHON_CLI_PARITY.md`'s gap list moves to
covered.

### Transfer (top-level, flat)
- `rename ENDPOINT:OLD NEW` · `stat ENDPOINT:PATH` · `delete ENDPOINT:PATH`
  (task-based, `--recursive`/`--ignore-missing`)
- `task event-list` · `task pause-info` · `task update` (`--label`/`--deadline`)

### Endpoint group
- `endpoint update` · `endpoint delete`
- `endpoint role list|show|create|delete`
- `endpoint permission list|show|create|update|delete` (ACLs)

### Bookmarks (new group)
- `bookmark list|show|create|rename|delete`

### Groups
- `join` / `leave` / `invite` — now real `BatchMembershipAction` calls (were
  stubs)
- `member accept|decline|approve|reject` (new)
- `group policies show|set` (new; `set` does get-modify-put so unset fields are
  preserved)

### Deferred (documented, not stubbed)
`session show|update|consent` — the Python CLI drives a high-assurance
reauth/session-boundary flow the v4 SDK doesn't expose (only `GetConsents`).

### Notes
- Built with 4 parallel subagents over disjoint files; shared `cmd/*.go` wiring
  done in the main session.
- `TestFlatCommandStructure` extended to assert the new top-level commands.
- Verified: `GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0
  issues; command tree renders correctly.