### PR TITLE
feat: api raw passthrough + real streams/tunnels (Phase 5)

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/scttfrdmn/globus-go-cli/cmd/api"
+)
+
+// getAPICommand returns the `api` raw-passthrough command group.
+func getAPICommand() *cobra.Command {
+	return api.APICmd()
+}

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+
+// Package api implements the top-level "globus api" raw-passthrough command
+// group. It mirrors the Python Globus CLI's `globus api <service> <METHOD>
+// <PATH>`: each subcommand issues an authenticated raw HTTP request to a Globus
+// service API and prints the JSON response. It is an escape hatch for calling
+// endpoints the typed commands do not yet cover.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/core"
+)
+
+// serviceSpec describes one "globus api <service>" subcommand: the CLI name,
+// the globusauth.Service used to mint a token, and the base URL relative paths
+// resolve against. Base URLs match the v4 SDK's service defaults. For auth,
+// groups, and search the base already includes a version segment (/v2, /v1);
+// PATH is joined onto it as given.
+type serviceSpec struct {
+	name    string
+	svc     globusauth.Service
+	baseURL string
+}
+
+// specs is the fixed set of raw-passthrough subcommands, one per service,
+// mirroring the Python CLI (note: "groups" and "timer" naming).
+var specs = []serviceSpec{
+	{name: "auth", svc: globusauth.ServiceAuth, baseURL: "https://auth.globus.org/v2"},
+	{name: "transfer", svc: globusauth.ServiceTransfer, baseURL: "https://transfer.api.globus.org"},
+	{name: "groups", svc: globusauth.ServiceGroups, baseURL: "https://groups.api.globus.org/v2"},
+	{name: "search", svc: globusauth.ServiceSearch, baseURL: "https://search.api.globus.org/v1"},
+	{name: "flows", svc: globusauth.ServiceFlows, baseURL: "https://flows.globus.org"},
+	{name: "timer", svc: globusauth.ServiceTimers, baseURL: "https://timer.automate.globus.org"},
+	{name: "compute", svc: globusauth.ServiceCompute, baseURL: "https://compute.api.globus.org"},
+}
+
+// APICmd returns the "api" command group with one raw-passthrough subcommand
+// per Globus service. It is exported for wiring into the root command.
+func APICmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "api",
+		Short: "Make authenticated raw HTTP requests to Globus service APIs",
+		Long: `Make authenticated raw HTTP requests to Globus service APIs.
+
+Each subcommand targets one service and takes an HTTP METHOD and a PATH,
+issuing the request with the current profile's stored token for that service
+and printing the JSON response. This is an escape hatch for endpoints not yet
+covered by the typed commands.
+
+Examples:
+  globus api transfer GET /endpoint_search --query filter_fulltext=example
+  globus api groups GET /groups/GROUP_ID
+  globus api flows POST /flows --body '{"title":"my flow"}'`,
+	}
+
+	for _, spec := range specs {
+		cmd.AddCommand(newServiceCmd(spec))
+	}
+
+	return cmd
+}
+
+// newServiceCmd builds the raw-passthrough subcommand for a single service.
+func newServiceCmd(spec serviceSpec) *cobra.Command {
+	var (
+		body        string
+		queryParams []string
+	)
+
+	c := &cobra.Command{
+		Use:   fmt.Sprintf("%s METHOD PATH", spec.name),
+		Short: fmt.Sprintf("Make a raw HTTP request to the Globus %s API", spec.name),
+		Long: fmt.Sprintf(`Make a raw, authenticated HTTP request to the Globus %s API.
+
+METHOD is an HTTP verb (GET, POST, PUT, PATCH, DELETE). PATH is the request
+path relative to %s (a leading slash is optional; any version prefix in the
+base URL is preserved). The JSON response is printed to stdout.`, spec.name, spec.baseURL),
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			method := strings.ToUpper(args[0])
+			rawPath := args[1]
+
+			profile := viper.GetString("profile")
+			clientCfg, err := config.LoadClientConfig()
+			if err != nil {
+				return fmt.Errorf("failed to load client configuration: %w", err)
+			}
+
+			cfg, err := globusauth.ClientConfig(ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret, spec.svc)
+			if err != nil {
+				return fmt.Errorf("not logged in: %w", err)
+			}
+			cfg.BaseURL = spec.baseURL
+
+			client, err := core.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			// Separate any query string embedded in PATH from the path itself,
+			// then merge in the repeated --query key=value entries.
+			path := rawPath
+			query := url.Values{}
+			if i := strings.IndexByte(rawPath, '?'); i >= 0 {
+				path = rawPath[:i]
+				embedded, perr := url.ParseQuery(rawPath[i+1:])
+				if perr != nil {
+					return fmt.Errorf("invalid query string in path: %w", perr)
+				}
+				for k, vs := range embedded {
+					for _, v := range vs {
+						query.Add(k, v)
+					}
+				}
+			}
+			for _, q := range queryParams {
+				k, v, found := strings.Cut(q, "=")
+				if !found {
+					return fmt.Errorf("invalid --query %q: expected key=value", q)
+				}
+				query.Add(k, v)
+			}
+			if len(query) == 0 {
+				query = nil
+			}
+
+			// Parse --body into a generic value so DoRequest JSON-encodes it.
+			var reqBody interface{}
+			if body != "" {
+				if err := json.Unmarshal([]byte(body), &reqBody); err != nil {
+					return fmt.Errorf("invalid --body JSON: %w", err)
+				}
+			}
+
+			var result interface{}
+			if err := client.DoRequest(ctx, method, path, query, reqBody, &result); err != nil {
+				return fmt.Errorf("request failed: %w", err)
+			}
+
+			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
+			return formatter.FormatOutput(result, nil)
+		},
+	}
+
+	c.Flags().StringVar(&body, "body", "", "Raw JSON request body")
+	c.Flags().StringArrayVar(&queryParams, "query", nil, "Query parameter as key=value (repeatable)")
+
+	return c
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -247,6 +247,7 @@ func addServiceCommands() {
 		getSearchCommand(),
 		getFlowsCommand(),
 		getComputeCommand(),
+		getAPICommand(),
 		getConfigCommand(),
 	)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -78,8 +78,8 @@ func TestFlatCommandStructure(t *testing.T) {
 	wantTopLevel := []string{
 		"login", "logout", "whoami", "get-identities", "device", "refresh", "tokens",
 		"ls", "mkdir", "rm", "rename", "stat", "delete", "transfer", "task", "endpoint",
-		"bookmark",
-		"group", "search", "flows", "timer", "compute", "config",
+		"bookmark", "tunnel", "stream-access-point",
+		"group", "search", "flows", "timer", "compute", "api", "config",
 	}
 	for _, name := range wantTopLevel {
 		if !have[name] {

--- a/cmd/transfer/stream_access_point.go
+++ b/cmd/transfer/stream_access_point.go
@@ -3,27 +3,39 @@
 package transfer
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
 )
+
+// sapLimit is the --limit flag value for stream-access-point list.
+var sapLimit int
 
 // StreamAccessPointCmd returns the stream-access-point subcommand group.
 //
-// Globus Streams (tunnels and stream access points) is a Python SDK v4.3.0+
-// feature and is not part of the frozen v3 SDK this CLI builds against, so these
-// commands are not available.
+// Globus Streams access points (Python SDK v4.3.0+) are backed by the v4
+// Transfer client. A stream access point exposes a collection path for use as a
+// listener or initiator endpoint of a Globus Streams tunnel.
 func StreamAccessPointCmd() *cobra.Command {
 	sapCmd := &cobra.Command{
 		Use:   "stream-access-point",
-		Short: "Commands for Globus Streams access points (unavailable)",
+		Short: "Commands for Globus Streams access points",
 		Long: `Commands for working with Globus Streams access points.
 
-NOTE: Globus Streams is a newer API not included in the SDK version this CLI
-builds against, so these commands are not available.`,
+A stream access point exposes a collection path for use as the listener or
+initiator endpoint of a Globus Streams tunnel.`,
 	}
 
-	sapCmd.AddCommand(streamAccessPointShowCmd())
+	sapCmd.AddCommand(
+		streamAccessPointShowCmd(),
+		streamAccessPointListCmd(),
+	)
 	return sapCmd
 }
 
@@ -31,10 +43,85 @@ builds against, so these commands are not available.`,
 func streamAccessPointShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show ACCESS_POINT_ID",
-		Short: "Show details of a Globus Streams access point (unavailable)",
+		Short: "Show details of a Globus Streams access point",
+		Long:  `Show detailed information about a specific Globus Streams access point.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("this SDK version does not support Globus Streams")
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			sap, err := client.GetStreamAccessPoint(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to get stream access point: %w", err)
+			}
+
+			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
+			if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+				return formatter.FormatOutput(sap, nil)
+			}
+
+			fmt.Println("Stream Access Point Details:")
+			fmt.Printf("  ID:           %s\n", sap.ID)
+			fmt.Printf("  Tunnel ID:    %s\n", sap.TunnelID)
+			fmt.Printf("  Endpoint ID:  %s\n", sap.EndpointID)
+			fmt.Printf("  Path:         %s\n", sap.Path)
+			fmt.Printf("  Access URL:   %s\n", sap.AccessURL)
+
+			return nil
 		},
 	}
+}
+
+// streamAccessPointListCmd returns the stream-access-point list command.
+func streamAccessPointListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Globus Streams access points",
+		Long:  `List Globus Streams access points visible to the current user.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.ListStreamAccessPoints(ctx, &transfer.ListTunnelsOptions{Limit: sapLimit})
+			if err != nil {
+				return fmt.Errorf("failed to list stream access points: %w", err)
+			}
+
+			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
+			if formatter.Format == output.FormatJSON {
+				return formatter.FormatOutput(resp.Data, nil)
+			}
+
+			type sapRow struct {
+				ID         string
+				TunnelID   string
+				EndpointID string
+				Path       string
+			}
+			rows := make([]sapRow, 0, len(resp.Data))
+			for _, s := range resp.Data {
+				rows = append(rows, sapRow{
+					ID:         s.ID,
+					TunnelID:   s.TunnelID,
+					EndpointID: s.EndpointID,
+					Path:       s.Path,
+				})
+			}
+			return formatter.FormatOutput(rows, []string{"ID", "TunnelID", "EndpointID", "Path"})
+		},
+	}
+
+	cmd.Flags().IntVar(&sapLimit, "limit", 25, "Maximum number of stream access points to return")
+
+	return cmd
 }

--- a/cmd/transfer/tunnel.go
+++ b/cmd/transfer/tunnel.go
@@ -3,47 +3,324 @@
 package transfer
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
+)
+
+// Flag variables for tunnel subcommands.
+var (
+	tunnelLimit        int
+	tunnelListener     string
+	tunnelInitiator    string
+	tunnelLabel        string
+	tunnelListenerPort int
+	tunnelListenerIP   string
+	tunnelLifetimeMins int
+	tunnelRestartable  bool
 )
 
 // TunnelCmd returns the tunnel subcommand group.
 //
-// Globus Streams tunnels are a Python SDK v4.3.0+ feature and are not part of
-// the frozen v3 SDK this CLI builds against, so these commands are not
-// available. The subcommands are retained so the help tree is stable, but each
-// returns a clear "unsupported" error.
+// Globus Streams tunnels (Python SDK v4.3.0+) are backed by the v4 Transfer
+// client. A tunnel connects a listener stream access point to an initiator
+// stream access point, enabling low-latency streaming data movement.
 func TunnelCmd() *cobra.Command {
 	tunnelCmd := &cobra.Command{
 		Use:   "tunnel",
-		Short: "Commands for managing Globus Streams tunnels (unavailable)",
+		Short: "Commands for managing Globus Streams tunnels",
 		Long: `Commands for managing Globus Streams tunnels.
 
-NOTE: Globus Streams is a newer API not included in the SDK version this CLI
-builds against, so these commands are not available.`,
+A tunnel connects a listener stream access point to an initiator stream access
+point, enabling streaming data movement between Globus collections.`,
 	}
 
 	tunnelCmd.AddCommand(
-		tunnelUnsupportedCmd("list", "List Globus Streams tunnels"),
-		tunnelUnsupportedCmd("create", "Create a Globus Streams tunnel"),
-		tunnelUnsupportedCmd("show", "Show a Globus Streams tunnel"),
-		tunnelUnsupportedCmd("update", "Update a Globus Streams tunnel"),
-		tunnelUnsupportedCmd("delete", "Delete a Globus Streams tunnel"),
-		tunnelUnsupportedCmd("events", "Show events for a Globus Streams tunnel"),
+		tunnelListCmd(),
+		tunnelShowCmd(),
+		tunnelCreateCmd(),
+		tunnelUpdateCmd(),
+		tunnelDeleteCmd(),
+		tunnelEventsCmd(),
 	)
 
 	return tunnelCmd
 }
 
-// tunnelUnsupportedCmd builds a placeholder subcommand that reports the feature
-// is unavailable in this SDK version.
-func tunnelUnsupportedCmd(use, short string) *cobra.Command {
-	return &cobra.Command{
-		Use:   use,
-		Short: short + " (unavailable)",
+// tunnelListCmd returns the tunnel list command.
+func tunnelListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Globus Streams tunnels",
+		Long:  `List Globus Streams tunnels visible to the current user.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("this SDK version does not support Globus Streams tunnels")
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.ListTunnels(ctx, &transfer.ListTunnelsOptions{Limit: tunnelLimit})
+			if err != nil {
+				return fmt.Errorf("failed to list tunnels: %w", err)
+			}
+
+			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
+			if formatter.Format == output.FormatJSON {
+				return formatter.FormatOutput(resp.Tunnels, nil)
+			}
+
+			type tunnelRow struct {
+				ID     string
+				Label  string
+				Status string
+				Source string
+				Owner  string
+			}
+			rows := make([]tunnelRow, 0, len(resp.Tunnels))
+			for _, t := range resp.Tunnels {
+				rows = append(rows, tunnelRow{
+					ID:     t.ID,
+					Label:  t.DisplayName,
+					Status: t.Status,
+					Source: t.SourceEndpointID + ":" + t.SourcePath,
+					Owner:  t.Owner,
+				})
+			}
+			return formatter.FormatOutput(rows, []string{"ID", "Label", "Status", "Source", "Owner"})
 		},
 	}
+
+	cmd.Flags().IntVar(&tunnelLimit, "limit", 25, "Maximum number of tunnels to return")
+
+	return cmd
+}
+
+// tunnelShowCmd returns the tunnel show command.
+func tunnelShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show TUNNEL_ID",
+		Short: "Show a Globus Streams tunnel",
+		Long:  `Show detailed information about a specific Globus Streams tunnel.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			tunnel, err := client.GetTunnel(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to get tunnel: %w", err)
+			}
+
+			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
+			if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+				return formatter.FormatOutput(tunnel, nil)
+			}
+
+			fmt.Println("Tunnel Details:")
+			fmt.Printf("  ID:             %s\n", tunnel.ID)
+			fmt.Printf("  Display Name:   %s\n", tunnel.DisplayName)
+			fmt.Printf("  Status:         %s\n", tunnel.Status)
+			fmt.Printf("  Source:         %s:%s\n", tunnel.SourceEndpointID, tunnel.SourcePath)
+			fmt.Printf("  Owner:          %s\n", tunnel.Owner)
+			if tunnel.ExpiresAt != nil {
+				fmt.Printf("  Expires At:     %s\n", tunnel.ExpiresAt.Format(time.RFC3339))
+			}
+
+			return nil
+		},
+	}
+}
+
+// tunnelCreateCmd returns the tunnel create command.
+func tunnelCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Globus Streams tunnel",
+		Long: `Create a Globus Streams tunnel connecting a listener stream access
+point to an initiator stream access point.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			create := &transfer.TunnelCreate{
+				ListenerStreamAccessPoint:  tunnelListener,
+				InitiatorStreamAccessPoint: tunnelInitiator,
+				Label:                      tunnelLabel,
+				ListenerIPAddress:          tunnelListenerIP,
+			}
+			if cmd.Flags().Changed("listener-port") {
+				port := tunnelListenerPort
+				create.ListenerPort = &port
+			}
+			if cmd.Flags().Changed("lifetime-mins") {
+				mins := tunnelLifetimeMins
+				create.LifetimeMins = &mins
+			}
+			if cmd.Flags().Changed("restartable") {
+				restartable := tunnelRestartable
+				create.Restartable = &restartable
+			}
+
+			tunnel, err := client.CreateTunnel(ctx, create)
+			if err != nil {
+				return fmt.Errorf("failed to create tunnel: %w", err)
+			}
+
+			fmt.Printf("Created tunnel %s (status: %s)\n", tunnel.ID, tunnel.Status)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&tunnelListener, "listener", "", "Listener stream access point ID (required)")
+	cmd.Flags().StringVar(&tunnelInitiator, "initiator", "", "Initiator stream access point ID (required)")
+	cmd.Flags().StringVar(&tunnelLabel, "label", "", "Human-readable label for the tunnel")
+	cmd.Flags().IntVar(&tunnelListenerPort, "listener-port", 0, "Listener port")
+	cmd.Flags().StringVar(&tunnelListenerIP, "listener-ip", "", "Listener IP address")
+	cmd.Flags().IntVar(&tunnelLifetimeMins, "lifetime-mins", 0, "Tunnel lifetime in minutes")
+	cmd.Flags().BoolVar(&tunnelRestartable, "restartable", false, "Whether the tunnel is restartable")
+
+	_ = cmd.MarkFlagRequired("listener")
+	_ = cmd.MarkFlagRequired("initiator")
+
+	return cmd
+}
+
+// tunnelUpdateCmd returns the tunnel update command.
+func tunnelUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update TUNNEL_ID",
+		Short: "Update a Globus Streams tunnel",
+		Long:  `Update the mutable fields of a Globus Streams tunnel.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			update := &transfer.TunnelUpdate{
+				Label:             tunnelLabel,
+				ListenerIPAddress: tunnelListenerIP,
+			}
+			if cmd.Flags().Changed("listener-port") {
+				port := tunnelListenerPort
+				update.ListenerPort = &port
+			}
+
+			if _, err := client.UpdateTunnel(ctx, args[0], update); err != nil {
+				return fmt.Errorf("failed to update tunnel: %w", err)
+			}
+
+			fmt.Printf("Updated tunnel %s\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&tunnelLabel, "label", "", "Human-readable label for the tunnel")
+	cmd.Flags().IntVar(&tunnelListenerPort, "listener-port", 0, "Listener port")
+	cmd.Flags().StringVar(&tunnelListenerIP, "listener-ip", "", "Listener IP address")
+
+	return cmd
+}
+
+// tunnelDeleteCmd returns the tunnel delete command.
+func tunnelDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete TUNNEL_ID",
+		Short: "Delete a Globus Streams tunnel",
+		Long:  `Delete a Globus Streams tunnel.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteTunnel(ctx, args[0]); err != nil {
+				return fmt.Errorf("failed to delete tunnel: %w", err)
+			}
+
+			fmt.Printf("Deleted tunnel %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+// tunnelEventsCmd returns the tunnel events command.
+func tunnelEventsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "events TUNNEL_ID",
+		Short: "Show events for a Globus Streams tunnel",
+		Long:  `Show the event history for a specific Globus Streams tunnel.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.GetTunnelEvents(ctx, args[0], &transfer.ListTunnelEventsOptions{Limit: tunnelLimit})
+			if err != nil {
+				return fmt.Errorf("failed to get tunnel events: %w", err)
+			}
+
+			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
+			if formatter.Format == output.FormatJSON {
+				return formatter.FormatOutput(resp.Events, nil)
+			}
+
+			type eventRow struct {
+				ID          string
+				Code        string
+				Description string
+				OccurredAt  string
+			}
+			rows := make([]eventRow, 0, len(resp.Events))
+			for _, e := range resp.Events {
+				occurred := ""
+				if e.OccurredAt != nil {
+					occurred = e.OccurredAt.Format(time.RFC3339)
+				}
+				rows = append(rows, eventRow{
+					ID:          e.ID,
+					Code:        e.Code,
+					Description: e.Description,
+					OccurredAt:  occurred,
+				})
+			}
+			return formatter.FormatOutput(rows, []string{"ID", "Code", "Description", "OccurredAt"})
+		},
+	}
+
+	cmd.Flags().IntVar(&tunnelLimit, "limit", 25, "Maximum number of events to return")
+
+	return cmd
 }

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -60,14 +60,14 @@ device-code flow and `identities lookup` performs a real `GetIdentities` call
 | Endpoint roles | ✅ (create/delete/list/show) | ✅ (`endpoint role list/show/create/delete`) | Covered (Phase 4) |
 | Endpoint permissions (ACLs) | ✅ (5) | ✅ (`endpoint permission list/show/create/update/delete`) | Covered (Phase 4) |
 | Bookmarks | ✅ (5) | ✅ (`bookmark list/show/create/rename/delete`) | Covered (Phase 4) |
-| Collections / GCS management | ✅ (`collection`, `gcs`, 32 cmds) | ❌ none | Gap (Phase 5 — v4 gcs service) |
+| Collections / GCS management | ✅ (`collection`, `gcs`, 32 cmds) | ❌ none | Blocked — SDK lacks endpoint GCS-manager URL + per-collection consent (see below) |
 | GCP (Connect Personal) | ✅ (6) | ❌ none | Gap (no SDK support) |
-| Streams / tunnels | ✅ (8) | Stubs (report "unavailable") | Gap (v4 transfer tunnels exist; Phase 5) |
+| Streams / tunnels | ✅ (8) | ✅ (`tunnel list/show/create/update/delete/events`, `stream-access-point list/show`) | Covered (Phase 5) |
 | Search (index/query/ingest/task/role/subject) | ✅ (14) | ✅ comparable | Covered |
 | Groups (member/role/policy/invite/join/leave) | ✅ (19) | ✅ — create/delete/list/show/update, member add/invite/list/remove/accept/decline/approve/reject, join/leave, `policies show/set` | Covered (Phase 4) |
 | Flows (create/run/list/show/update/validate/logs) | ✅ (17) | ✅ comparable | Covered |
 | Timers | ✅ (7) | ✅ (create/list/show/pause/resume/delete) | Covered |
-| `api` raw passthrough | ✅ (7 services) | ❌ none | Gap (Phase 5) |
+| `api` raw passthrough | ✅ (7 services) | ✅ (`api auth/transfer/groups/search/flows/timer/compute`) | Covered (Phase 5) |
 | `session` (consent/show/update) | ✅ (3) | ❌ none | Gap — needs reauth/session-boundary support not in the v4 SDK (only `GetConsents`) |
 | Compute | ❌ (not in Python CLI) | ✅ (endpoint/function/task) | Go-only extension |
 
@@ -99,15 +99,27 @@ Still available in the SDK but not yet wired:
 
 ### B. Gaps with no v3 SDK support (need SDK work first, or are out of scope)
 
-- **GCS / collections management** (`collection`, `gcs`, ~32 commands) — the v4
-  SDK module has a `gcs` service. Now that the service commands build on v4
-  (Phase 2b), wiring these up is CLI work rather than an SDK blocker.
-- **GCP (Globus Connect Personal)** — local-agent management; not an SDK API.
-- **Streams / tunnels** — a Python globus-sdk v4.3.0+ feature. The v4 Go SDK
-  transfer client now exposes tunnel/stream-access-point methods, so these are
-  becoming supportable; the CLI currently ships "unavailable" stubs.
-- **`api` raw passthrough** — convenience for arbitrary API calls; no SDK method,
-  would be a thin HTTP wrapper.
+- **`api` raw passthrough** — DONE (Phase 5). `globus api <service> METHOD PATH`
+  for auth/transfer/groups/search/flows/timer/compute, over the core client.
+- **Streams / tunnels** — DONE (Phase 5). The v4 transfer client's
+  tunnel/stream-access-point methods now back real `tunnel` and
+  `stream-access-point` commands (the "unavailable" stubs are gone).
+- **GCS / collections management** (`collection`, `gcs`, ~32 commands) —
+  **still blocked**, and NOT merely CLI wiring. The v4 SDK's `gcs.CollectionClient`
+  needs two things the rest of the CLI doesn't have:
+  1. the endpoint's **GCS Manager URL** (`https://<gcs-host>/api`), which is not
+     exposed on the v4 SDK's transfer `Endpoint` struct — there is no field to
+     read it from, so the client address can't be constructed from a collection
+     ID alone; and
+  2. **dynamic per-collection consent** — each collection has its own
+     `.../<collection-id>/https` and `.../data_access` scopes, but the CLI's
+     GlobusApp login requests only a fixed scope set, so `GetAuthorizer` has no
+     token for a given collection's data-access scope.
+  Wiring `collection`/`gcs` needs SDK support to surface the manager URL (e.g. on
+  the endpoint document) and a consent/scope-escalation path in `pkg/globusauth`.
+  Deferred to a future phase (tracked as SDK work).
+- **GCP (Globus Connect Personal)** — local-agent management; not an SDK API
+  (out of scope).
 
 ## Compute is a Go-only extension
 


### PR DESCRIPTION
## Phase 5 — `api` passthrough, streams/tunnels; GCS deferred

### `api` raw passthrough (new)
`globus api <service> METHOD PATH` for auth/transfer/groups/search/flows/timer/
compute — matches the Python CLI. Builds a core client with the service base URL
and the profile's per-resource-server authorizer, issues the raw request via
`core.DoRequest`, and prints the JSON response through the shared formatter
(`-F`/`--jq` work). Flags: `--body` (JSON), `--query key=value` (repeatable);
`?query` embedded in PATH is merged in.

### Streams / tunnels (stubs → real)
Replaced the "unavailable" stubs with real v4-transfer-client-backed commands:
- `tunnel list|show|create|update|delete|events`
- `stream-access-point list|show`

### GCS / collections — deferred (documented, not stubbed)
This is a genuine SDK blocker, not just CLI wiring. The v4
`gcs.CollectionClient` needs (1) the endpoint's **GCS Manager URL**, which the
SDK's transfer `Endpoint` struct does not expose, and (2) **dynamic
per-collection `data_access` consent** the CLI's fixed-scope GlobusApp login
doesn't request. `docs/PYTHON_CLI_PARITY.md` explains what SDK support is needed.

### Notes
- Dropped the `api --content-type` flag — the core client sets `Content-Type`
  itself, so it was a no-op.
- Built with 2 parallel subagents (streams; api) over disjoint files.
- `TestFlatCommandStructure` extended for `api`/`tunnel`/`stream-access-point`.
- Verified: `GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues.