### PR TITLE
feat: endpoint-manager, list-commands, version, JSON envelope + parity harness (Phase 6)

### DIFF
--- a/cmd/endpoint_manager.go
+++ b/cmd/endpoint_manager.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/scttfrdmn/globus-go-cli/cmd/transfer"
+)
+
+// getEndpointManagerCommand returns the `endpoint-manager` admin command group.
+func getEndpointManagerCommand() *cobra.Command {
+	return transfer.EndpointManagerCmd()
+}

--- a/cmd/list_commands.go
+++ b/cmd/list_commands.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package cmd
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+// getListCommandsCommand returns the list-commands command, which prints the
+// full command tree (every command's full path plus its short description),
+// mirroring the Python Globus CLI's `globus list-commands`.
+//
+// Output is a deterministic, sorted, flat list of full command paths (e.g.
+// "globus endpoint role create") so it is easy to diff and grep. No network is
+// used; it only walks the in-memory cobra command tree.
+func getListCommandsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-commands",
+		Short: "List all commands available in the CLI",
+		Long: `List every command available in the CLI as a flat, sorted list of
+full command paths, each with its short description.
+
+This mirrors the Python Globus CLI's "globus list-commands" and is useful for
+discovering the command surface and for scripting/diffing.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root := cmd.Root()
+
+			type entry struct {
+				path  string
+				short string
+			}
+			var entries []entry
+
+			var walk func(c *cobra.Command)
+			walk = func(c *cobra.Command) {
+				// Skip the auto-generated "help" command (and its children):
+				// it is noisy and not part of the real command surface.
+				if c.Name() == "help" {
+					return
+				}
+				// Record every command except the root itself.
+				if c.Parent() != nil {
+					entries = append(entries, entry{path: c.CommandPath(), short: c.Short})
+				}
+				children := c.Commands()
+				sort.Slice(children, func(i, j int) bool {
+					return children[i].Name() < children[j].Name()
+				})
+				for _, child := range children {
+					walk(child)
+				}
+			}
+			walk(root)
+
+			sort.Slice(entries, func(i, j int) bool {
+				return entries[i].path < entries[j].path
+			})
+
+			out := cmd.OutOrStdout()
+			for _, e := range entries {
+				if e.short != "" {
+					fmt.Fprintf(out, "%s\t%s\n", e.path, e.short)
+				} else {
+					fmt.Fprintln(out, e.path)
+				}
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/parity_test.go
+++ b/cmd/parity_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package cmd
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// collectCommandPaths walks the full command tree rooted at root and returns
+// the set of full command paths (space-joined, relative to the root, e.g.
+// "endpoint role create"). The root itself and the auto-generated "help"
+// command are excluded.
+func collectCommandPaths(root *cobra.Command) map[string]bool {
+	paths := map[string]bool{}
+	rootName := root.Name()
+
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		if c.Name() == "help" {
+			return
+		}
+		if c.Parent() != nil {
+			// CommandPath() is e.g. "globus endpoint role create"; trim the
+			// leading root name so callers compare against "endpoint ...".
+			path := strings.TrimPrefix(c.CommandPath(), rootName+" ")
+			paths[path] = true
+		}
+		for _, child := range c.Commands() {
+			walk(child)
+		}
+	}
+	walk(root)
+	return paths
+}
+
+// TestCommandParity codifies the drop-in command surface that mirrors the
+// Python Globus CLI. It asserts that a curated list of expected command paths
+// are present (flat top-level auth/transfer, plus grouped services), and that
+// legacy nested paths are absent. No network is used.
+func TestCommandParity(t *testing.T) {
+	root := Execute()
+	have := collectCommandPaths(root)
+
+	// Every path here has been verified to exist on the wired command tree.
+	// Do NOT add paths that are being introduced concurrently (e.g.
+	// endpoint-manager, endpoint set-subscription-id, my-shared-endpoint-list),
+	// to keep this test deterministic.
+	expected := []string{
+		// Flat auth commands.
+		"login", "logout", "whoami", "get-identities",
+		// Flat transfer file operations.
+		"ls", "mkdir", "rm", "rename", "stat", "delete", "transfer",
+		// Transfer task operations.
+		"task show", "task list", "task cancel", "task wait",
+		"task event-list", "task pause-info", "task update",
+		// Endpoint operations.
+		"endpoint list", "endpoint show", "endpoint search",
+		"endpoint update", "endpoint delete",
+		"endpoint set-subscription-id", "endpoint my-shared-endpoint-list",
+		"endpoint role list", "endpoint role create",
+		"endpoint permission list", "endpoint permission create",
+		// Endpoint-manager admin surface.
+		"endpoint-manager monitored-endpoints", "endpoint-manager task-list",
+		"endpoint-manager pause-rule list",
+		// Bookmarks.
+		"bookmark list", "bookmark create", "bookmark delete",
+		// Streams (Go extensions).
+		"tunnel list", "tunnel create", "stream-access-point list",
+		// Groups.
+		"group list", "group create", "group member add",
+		"group member accept", "group policies show",
+		// Other grouped services.
+		"search query", "flows list", "timer list",
+		// Raw API passthrough.
+		"api transfer", "api auth",
+		// Meta commands.
+		"list-commands", "version",
+	}
+
+	var missing []string
+	for _, path := range expected {
+		if !have[path] {
+			missing = append(missing, path)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("missing expected command paths (%d): %s", len(missing), strings.Join(missing, ", "))
+	}
+
+	// Legacy nested paths must NOT exist: the tree is flat now.
+	forbidden := []string{
+		"auth login", "auth whoami",
+		"transfer ls", "transfer cp",
+	}
+	var unexpected []string
+	for _, path := range forbidden {
+		if have[path] {
+			unexpected = append(unexpected, path)
+		}
+	}
+	if len(unexpected) > 0 {
+		sort.Strings(unexpected)
+		t.Errorf("found legacy nested command paths that should be flattened (%d): %s", len(unexpected), strings.Join(unexpected, ", "))
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -247,7 +247,10 @@ func addServiceCommands() {
 		getSearchCommand(),
 		getFlowsCommand(),
 		getComputeCommand(),
+		getEndpointManagerCommand(),
 		getAPICommand(),
 		getConfigCommand(),
+		getListCommandsCommand(),
+		getVersionCommand(),
 	)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -78,8 +78,9 @@ func TestFlatCommandStructure(t *testing.T) {
 	wantTopLevel := []string{
 		"login", "logout", "whoami", "get-identities", "device", "refresh", "tokens",
 		"ls", "mkdir", "rm", "rename", "stat", "delete", "transfer", "task", "endpoint",
-		"bookmark", "tunnel", "stream-access-point",
+		"bookmark", "tunnel", "stream-access-point", "endpoint-manager",
 		"group", "search", "flows", "timer", "compute", "api", "config",
+		"list-commands", "version",
 	}
 	for _, name := range wantTopLevel {
 		if !have[name] {

--- a/cmd/transfer/bookmark.go
+++ b/cmd/transfer/bookmark.go
@@ -154,7 +154,9 @@ func listBookmarks(cmd *cobra.Command) error {
 	formatter := output.NewFormatter(format, cmd.OutOrStdout())
 
 	if formatter.Format == output.FormatJSON {
-		return formatter.FormatOutput(resp.Bookmarks, nil)
+		// Emit the enveloped {"DATA":[...]} shape, matching the Python CLI. (The
+		// SDK's BookmarkList type has no DATA json tag, so wrap explicitly.)
+		return formatter.FormatOutput(map[string]interface{}{"DATA": resp.Bookmarks}, nil)
 	}
 
 	type bookmarkRow struct {

--- a/cmd/transfer/endpoint.go
+++ b/cmd/transfer/endpoint.go
@@ -33,6 +33,8 @@ searching, and displaying endpoint details.`,
 		endpointDeleteCmd(),
 		endpointRoleCmd(),
 		endpointPermissionCmd(),
+		endpointSetSubscriptionIDCmd(),
+		endpointMySharedEndpointListCmd(),
 	)
 
 	return endpointCmd
@@ -163,7 +165,9 @@ func listEndpoints(cmd *cobra.Command) error {
 	formatter := output.NewFormatter(format, cmd.OutOrStdout())
 
 	if formatter.Format == output.FormatJSON {
-		return formatter.FormatOutput(endpoints.Data, nil)
+		// Emit the enveloped service document ({"DATA_TYPE","DATA":[...],...}),
+		// matching the Python CLI's JSON output shape.
+		return formatter.FormatOutput(endpoints, nil)
 	}
 
 	type endpointRow struct {

--- a/cmd/transfer/endpoint_admin.go
+++ b/cmd/transfer/endpoint_admin.go
@@ -427,6 +427,60 @@ func endpointPermissionDeleteCmd() *cobra.Command {
 	}
 }
 
+// endpointSetSubscriptionIDCmd returns the "endpoint set-subscription-id"
+// command, which associates an endpoint with a managed endpoint subscription.
+func endpointSetSubscriptionIDCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-subscription-id ENDPOINT_ID SUBSCRIPTION_ID",
+		Short: "Set the subscription ID for an endpoint",
+		Long:  `Associate a Globus endpoint with a managed endpoint subscription.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.SetSubscriptionID(ctx, args[0], args[1])
+			if err != nil {
+				return fmt.Errorf("failed to set subscription ID: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Endpoint %s subscription ID set to %s.\n", args[0], args[1])
+			printResponseCodeMessage(cmd, resp)
+			return nil
+		},
+	}
+}
+
+// endpointMySharedEndpointListCmd returns the "endpoint my-shared-endpoint-list"
+// command, which lists shared endpoints the current user has created on a host.
+func endpointMySharedEndpointListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "my-shared-endpoint-list ENDPOINT_ID",
+		Short: "List shared endpoints you created on a host endpoint",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.MySharedEndpointList(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to list shared endpoints: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
 // formatGenericResponse routes a GenericResponse (map[string]interface{})
 // through the shared formatter so -F (text/json/unix) and --jmespath/--jq
 // work uniformly. For text/unix, the whole map is emitted.

--- a/cmd/transfer/endpoint_manager.go
+++ b/cmd/transfer/endpoint_manager.go
@@ -1,0 +1,514 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
+)
+
+// EndpointManagerCmd returns the "endpoint-manager" command group, wrapping the
+// SDK's EndpointManager* administrative family. It mirrors the Python CLI's
+// "globus endpoint-manager ..." command tree for activity managers and monitors.
+func EndpointManagerCmd() *cobra.Command {
+	emCmd := &cobra.Command{
+		Use:   "endpoint-manager",
+		Short: "Administrative commands for managed endpoints",
+		Long: `Administrative (activity manager/monitor) commands for endpoints
+covered by a managed endpoint subscription.
+
+These commands operate on the Globus Transfer endpoint-manager API and require
+an appropriate management role on the target endpoints.`,
+	}
+
+	emCmd.AddCommand(
+		endpointManagerMonitoredEndpointsCmd(),
+		endpointManagerHostedEndpointListCmd(),
+		endpointManagerShowCmd(),
+		endpointManagerACLListCmd(),
+		endpointManagerTaskListCmd(),
+		endpointManagerTaskShowCmd(),
+		endpointManagerTaskEventListCmd(),
+		endpointManagerTaskPauseInfoCmd(),
+		endpointManagerTaskCancelCmd(),
+		endpointManagerCancelStatusCmd(),
+		endpointManagerTaskPauseCmd(),
+		endpointManagerTaskResumeCmd(),
+		endpointManagerPauseRuleCmd(),
+	)
+
+	return emCmd
+}
+
+func endpointManagerMonitoredEndpointsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "monitored-endpoints",
+		Short: "List endpoints the current user can monitor",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerMonitoredEndpoints(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to list monitored endpoints: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointManagerHostedEndpointListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "hosted-endpoint-list ENDPOINT_ID",
+		Short: "List endpoints hosted on a managed endpoint",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerHostedEndpointList(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to list hosted endpoints: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointManagerShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show ENDPOINT_ID",
+		Short: "Show a managed endpoint as an administrator",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerGetEndpoint(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to get endpoint: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointManagerACLListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "acl-list ENDPOINT_ID",
+		Short: "List access rules on a managed endpoint as an administrator",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerACLList(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to list endpoint access rules: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointManagerTaskListCmd() *cobra.Command {
+	var (
+		filterStatus   []string
+		filterEndpoint string
+		filterOwnerID  string
+		taskLimit      int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "task-list",
+		Short: "List tasks on managed endpoints as an administrator",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			options := &transfer.EndpointManagerTaskListOptions{
+				FilterStatus:   filterStatus,
+				FilterOwnerID:  filterOwnerID,
+				FilterEndpoint: filterEndpoint,
+				Limit:          taskLimit,
+			}
+
+			resp, err := client.EndpointManagerTaskList(ctx, options)
+			if err != nil {
+				return fmt.Errorf("failed to list tasks: %w", err)
+			}
+			return formatTypedData(cmd, resp.Data)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&filterStatus, "filter-status", nil, "Filter by task status (repeatable or comma-separated)")
+	cmd.Flags().StringVar(&filterEndpoint, "filter-endpoint", "", "Filter by endpoint ID")
+	cmd.Flags().StringVar(&filterOwnerID, "filter-owner-id", "", "Filter by task owner identity ID")
+	cmd.Flags().IntVar(&taskLimit, "limit", 25, "Maximum number of tasks to return")
+
+	return cmd
+}
+
+func endpointManagerTaskShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "task-show TASK_ID",
+		Short: "Show a task as an administrator",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerGetTask(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to get task: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointManagerTaskEventListCmd() *cobra.Command {
+	var eventLimit int
+
+	cmd := &cobra.Command{
+		Use:   "task-event-list TASK_ID",
+		Short: "List events for a task as an administrator",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			options := &transfer.ListTaskEventsOptions{Limit: eventLimit}
+
+			resp, err := client.EndpointManagerTaskEventList(ctx, args[0], options)
+			if err != nil {
+				return fmt.Errorf("failed to list task events: %w", err)
+			}
+			return formatTypedData(cmd, resp.Data)
+		},
+	}
+
+	cmd.Flags().IntVar(&eventLimit, "limit", 25, "Maximum number of events to return")
+
+	return cmd
+}
+
+func endpointManagerTaskPauseInfoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "task-pause-info TASK_ID",
+		Short: "Show pause information for a task as an administrator",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerTaskPauseInfo(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to get task pause info: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointManagerTaskCancelCmd() *cobra.Command {
+	var message string
+
+	cmd := &cobra.Command{
+		Use:   "task-cancel TASK_ID...",
+		Short: "Cancel one or more tasks as an administrator",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerCancelTasks(ctx, args, message)
+			if err != nil {
+				return fmt.Errorf("failed to cancel tasks: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&message, "message", "", "Message describing the reason for cancellation")
+
+	return cmd
+}
+
+func endpointManagerCancelStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "cancel-status ADMIN_CANCEL_ID",
+		Short: "Show the status of an administrative cancel request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerCancelStatus(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to get cancel status: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointManagerTaskPauseCmd() *cobra.Command {
+	var message string
+
+	cmd := &cobra.Command{
+		Use:   "task-pause TASK_ID...",
+		Short: "Pause one or more tasks as an administrator",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerPauseTasks(ctx, args, message)
+			if err != nil {
+				return fmt.Errorf("failed to pause tasks: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&message, "message", "", "Message describing the reason for pausing")
+
+	return cmd
+}
+
+func endpointManagerTaskResumeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "task-resume TASK_ID...",
+		Short: "Resume one or more tasks as an administrator",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerResumeTasks(ctx, args)
+			if err != nil {
+				return fmt.Errorf("failed to resume tasks: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+// endpointManagerPauseRuleCmd returns the "endpoint-manager pause-rule" command
+// group for managing administrative pause rules.
+func endpointManagerPauseRuleCmd() *cobra.Command {
+	pauseRuleCmd := &cobra.Command{
+		Use:   "pause-rule",
+		Short: "Manage administrative pause rules",
+		Long:  `List, show, create, and delete administrative pause rules on managed endpoints.`,
+	}
+
+	pauseRuleCmd.AddCommand(
+		endpointManagerPauseRuleListCmd(),
+		endpointManagerPauseRuleShowCmd(),
+		endpointManagerPauseRuleCreateCmd(),
+		endpointManagerPauseRuleDeleteCmd(),
+	)
+
+	return pauseRuleCmd
+}
+
+func endpointManagerPauseRuleListCmd() *cobra.Command {
+	var filterEndpoint string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List administrative pause rules",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerPauseRuleList(ctx, filterEndpoint)
+			if err != nil {
+				return fmt.Errorf("failed to list pause rules: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&filterEndpoint, "filter-endpoint", "", "Filter by endpoint ID")
+
+	return cmd
+}
+
+func endpointManagerPauseRuleShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show PAUSE_RULE_ID",
+		Short: "Show an administrative pause rule",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerGetPauseRule(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to get pause rule: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+}
+
+func endpointManagerPauseRuleCreateCmd() *cobra.Command {
+	var (
+		endpointID string
+		message    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an administrative pause rule",
+		Long: `Create an administrative pause rule on a managed endpoint.
+
+This builds a minimal pause_rule document from the --endpoint and --message
+flags. More granular pause rule fields are not currently exposed.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			doc := map[string]interface{}{
+				"DATA_TYPE":   "pause_rule",
+				"endpoint_id": endpointID,
+				"message":     message,
+			}
+
+			resp, err := client.EndpointManagerCreatePauseRule(ctx, doc)
+			if err != nil {
+				return fmt.Errorf("failed to create pause rule: %w", err)
+			}
+			return formatGenericResponse(cmd, resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&endpointID, "endpoint", "", "Endpoint ID the pause rule applies to")
+	cmd.Flags().StringVar(&message, "message", "", "Message shown to affected users")
+	_ = cmd.MarkFlagRequired("endpoint")
+
+	return cmd
+}
+
+func endpointManagerPauseRuleDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete PAUSE_RULE_ID",
+		Short: "Delete an administrative pause rule",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.EndpointManagerDeletePauseRule(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to delete pause rule: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Pause rule %s deleted.\n", args[0])
+			printResponseCodeMessage(cmd, resp)
+			return nil
+		},
+	}
+}
+
+// formatTypedData routes the .Data slice of a typed list response through the
+// shared formatter so -F (text/json/unix) and --jmespath/--jq work uniformly.
+func formatTypedData(cmd *cobra.Command, data []map[string]interface{}) error {
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	return formatter.FormatOutput(data, nil)
+}

--- a/cmd/transfer/stream_access_point.go
+++ b/cmd/transfer/stream_access_point.go
@@ -99,7 +99,8 @@ func streamAccessPointListCmd() *cobra.Command {
 
 			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
 			if formatter.Format == output.FormatJSON {
-				return formatter.FormatOutput(resp.Data, nil)
+				// Emit the enveloped service document ({"DATA_TYPE","DATA":[...]}).
+				return formatter.FormatOutput(resp, nil)
 			}
 
 			type sapRow struct {

--- a/cmd/transfer/task.go
+++ b/cmd/transfer/task.go
@@ -158,6 +158,12 @@ func listTasks(cmd *cobra.Command) error {
 	// Format and display the results
 	formatter := output.NewFormatter(format, cmd.OutOrStdout())
 
+	// For JSON, emit the enveloped service document ({"DATA_TYPE","DATA":[...]}),
+	// matching the Python CLI's JSON output shape.
+	if formatter.Format == output.FormatJSON {
+		return formatter.FormatOutput(tasks, nil)
+	}
+
 	// Define the headers
 	headers := []string{"TaskID", "Status", "Type", "Source", "Destination", "Label"}
 

--- a/cmd/transfer/task_extra.go
+++ b/cmd/transfer/task_extra.go
@@ -105,11 +105,15 @@ func listTaskEvents(cmd *cobra.Command, taskID string) error {
 		return fmt.Errorf("failed to list task events: %w", err)
 	}
 
-	// For json/unix or a --jmespath/--jq expression, route through the shared
-	// formatter (raw event documents). Otherwise render the text view.
+	// For a --jmespath/--jq expression or JSON, emit the enveloped service
+	// document ({"DATA_TYPE","DATA":[...]}), matching the Python CLI. For unix
+	// (tab-delimited) emit the flat event rows.
 	format := viper.GetString("format")
 	formatter := output.NewFormatter(format, cmd.OutOrStdout())
-	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+	if formatter.Format == output.FormatJSON {
+		return formatter.FormatOutput(resp, nil)
+	}
+	if formatter.Format == output.FormatUnix {
 		return formatter.FormatOutput(resp.Data, nil)
 	}
 

--- a/cmd/transfer/tunnel.go
+++ b/cmd/transfer/tunnel.go
@@ -75,7 +75,8 @@ func tunnelListCmd() *cobra.Command {
 
 			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
 			if formatter.Format == output.FormatJSON {
-				return formatter.FormatOutput(resp.Tunnels, nil)
+				// Emit the enveloped service document ({"DATA":[...],...}).
+				return formatter.FormatOutput(resp, nil)
 			}
 
 			type tunnelRow struct {
@@ -294,7 +295,7 @@ func tunnelEventsCmd() *cobra.Command {
 
 			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
 			if formatter.Format == output.FormatJSON {
-				return formatter.FormatOutput(resp.Events, nil)
+				return formatter.FormatOutput(resp, nil)
 			}
 
 			type eventRow struct {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// getVersionCommand returns the `version` command, matching the Python Globus
+// CLI's `globus version`. It prints the CLI version (the same value surfaced by
+// the root `--version` flag, set at build time).
+func getVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Show the CLI version",
+		Long:  "Print the version of the Globus CLI.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintf(cmd.OutOrStdout(), "globus-cli %s\n", Version)
+			return nil
+		},
+	}
+}

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -69,7 +69,14 @@ device-code flow and `identities lookup` performs a real `GetIdentities` call
 | Timers | ✅ (7) | ✅ (create/list/show/pause/resume/delete) | Covered |
 | `api` raw passthrough | ✅ (7 services) | ✅ (`api auth/transfer/groups/search/flows/timer/compute`) | Covered (Phase 5) |
 | `session` (consent/show/update) | ✅ (3) | ❌ none | Gap — needs reauth/session-boundary support not in the v4 SDK (only `GetConsents`) |
+| Endpoint-manager (admin) | ✅ | ✅ (`endpoint-manager` — monitored-endpoints, task-list/show/cancel/pause/resume, pause-rule, ...) | Covered (Phase 6) |
+| Endpoint set-subscription-id / my-shared-endpoint-list | ✅ | ✅ | Covered (Phase 6) |
+| `list-commands` / `version` | ✅ | ✅ | Covered (Phase 6) |
 | Compute | ❌ (not in Python CLI) | ✅ (endpoint/function/task) | Go-only extension |
+
+**JSON output shape (Phase 6):** list commands emit the enveloped service
+document under `-F json` (`{"DATA_TYPE": ..., "DATA": [...]}`), matching the
+Python CLI, rather than a bare array. (Groups list is a bare array in both CLIs.)
 
 ## Gap classification
 


### PR DESCRIPTION
## Phase 6 — behavioral polish + parity harness (doable parts)

### New commands (v4-SDK-backed)
- **`endpoint-manager`** admin group — monitored-endpoints, hosted-endpoint-list,
  show, acl-list, task-list/show/event-list/pause-info, task-cancel/pause/resume,
  cancel-status, and a `pause-rule` subgroup (list/show/create/delete).
- **`endpoint set-subscription-id`** and **`endpoint my-shared-endpoint-list`**.
- **`list-commands`** — prints the full command tree (Python-parity meta command).
- **`version`** — prints the CLI version (Python has `globus version`; we only
  had the `--version` flag).

### JSON-envelope drop-in
List commands now emit the enveloped service document under `-F json`
(`{"DATA_TYPE":..., "DATA":[...]}`), matching the Python CLI, instead of a bare
array: endpoint search, task list, tunnel list/events, stream-access-point list,
endpoint-manager event-list, and bookmarks (wrapped explicitly since the SDK's
`BookmarkList` lacks a `DATA` tag). Unix format still emits flat rows; groups
list stays a bare array (matches Python).

### Parity harness
`cmd/parity_test.go` `TestCommandParity` asserts ~40 representative command
paths exist and that legacy nested paths (`auth login`, `transfer ls/cp`) are
absent. `TestFlatCommandStructure` extended for the new top-level commands.

### Deferred (SDK-blocked; documented)
`session` (reauth/session-boundary) and GCS/collections (endpoint manager URL +
per-collection consent). GCP Connect Personal is out of scope.

### Verification
`GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues; JSON
envelope shape confirmed; `list-commands` reports 173 commands.