### PR TITLE
feat(auth): session show (+ pin v4 SDK v4.8.1-2)

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -20,5 +20,6 @@ func addAuthCommands(root *cobra.Command) {
 		auth.RefreshCmd(),
 		auth.TokensCmd(),
 		auth.GetIdentitiesCmd(),
+		auth.SessionCmd(),
 	)
 }

--- a/cmd/auth/session.go
+++ b/cmd/auth/session.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package auth
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
+)
+
+// SessionCmd returns the `session` command group, matching the Python Globus
+// CLI's `globus session`. Currently only `show` is available: `update` and
+// `consent` require a reauthentication / session-boundary flow the SDK does not
+// yet expose.
+func SessionCmd() *cobra.Command {
+	sessionCmd := &cobra.Command{
+		Use:   "session",
+		Short: "Commands for managing your Globus Auth session",
+		Long: `Commands for inspecting your current Globus Auth session.
+
+A session records which of your identities have authenticated and when — the
+basis for high-assurance ("session boundary") access decisions.`,
+	}
+
+	sessionCmd.AddCommand(sessionShowCmd())
+	return sessionCmd
+}
+
+// sessionShowCmd returns the `session show` command.
+func sessionShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Show your current Globus Auth session",
+		Long: `Show the identities that have authenticated in your current Globus Auth
+session and when each authenticated.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profile := viper.GetString("profile")
+
+			// Read the stored auth token to introspect.
+			td, err := globusauth.TokenFor(profile, globusauth.ServiceAuth)
+			if err != nil {
+				return fmt.Errorf("not logged in: %w", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			// Introspection authenticates the client with Basic auth.
+			authClient, err := newRevokeAuthClient(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to create auth client: %w", err)
+			}
+
+			intro, err := authClient.IntrospectToken(ctx, td.AccessToken, &auth.IntrospectOptions{Include: "session_info"})
+			if err != nil {
+				return fmt.Errorf("failed to introspect session: %w", err)
+			}
+
+			// For JSON/unix or a --jq expression, emit the raw session_info.
+			format := viper.GetString("format")
+			formatter := output.NewFormatter(format, cmd.OutOrStdout())
+			if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+				return formatter.FormatOutput(intro.SessionInfo, nil)
+			}
+
+			if intro.SessionInfo == nil || len(intro.SessionInfo.Authentications) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No authenticated identities in the current session.")
+				return nil
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Session ID: %s\n\n", intro.SessionInfo.SessionID)
+
+			// Stable output: sort by identity ID.
+			ids := make([]string, 0, len(intro.SessionInfo.Authentications))
+			for id := range intro.SessionInfo.Authentications {
+				ids = append(ids, id)
+			}
+			sort.Strings(ids)
+
+			type row struct {
+				IdentityID     string
+				AuthenticatedAt string
+				MFA            bool
+			}
+			rows := make([]row, 0, len(ids))
+			for _, id := range ids {
+				a := intro.SessionInfo.Authentications[id]
+				at := ""
+				if a.AuthTime > 0 {
+					at = time.Unix(a.AuthTime, 0).Format(time.RFC3339)
+				}
+				mfa := false
+				for _, m := range a.AMR {
+					if m == "mfa" {
+						mfa = true
+						break
+					}
+				}
+				rows = append(rows, row{IdentityID: id, AuthenticatedAt: at, MFA: mfa})
+			}
+			return formatter.FormatOutput(rows, []string{"IdentityID", "AuthenticatedAt", "MFA"})
+		},
+	}
+}

--- a/cmd/parity_test.go
+++ b/cmd/parity_test.go
@@ -77,6 +77,8 @@ func TestCommandParity(t *testing.T) {
 		"search query", "flows list", "timer list",
 		// Raw API passthrough.
 		"api transfer", "api auth",
+		// Session.
+		"session show",
 		// Meta commands.
 		"list-commands", "version",
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -76,7 +76,7 @@ func TestFlatCommandStructure(t *testing.T) {
 
 	// These must exist at the top level (flattened from auth/transfer).
 	wantTopLevel := []string{
-		"login", "logout", "whoami", "get-identities", "device", "refresh", "tokens",
+		"login", "logout", "whoami", "get-identities", "device", "refresh", "tokens", "session",
 		"ls", "mkdir", "rm", "rename", "stat", "delete", "transfer", "task", "endpoint",
 		"bookmark", "tunnel", "stream-access-point", "endpoint-manager",
 		"group", "search", "flows", "timer", "compute", "api", "config",

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -68,7 +68,7 @@ device-code flow and `identities lookup` performs a real `GetIdentities` call
 | Flows (create/run/list/show/update/validate/logs) | ✅ (17) | ✅ comparable | Covered |
 | Timers | ✅ (7) | ✅ (create/list/show/pause/resume/delete) | Covered |
 | `api` raw passthrough | ✅ (7 services) | ✅ (`api auth/transfer/groups/search/flows/timer/compute`) | Covered (Phase 5) |
-| `session` (consent/show/update) | ✅ (3) | ❌ none | Gap — needs reauth/session-boundary support not in the v4 SDK (only `GetConsents`) |
+| `session` (consent/show/update) | ✅ (3) | Partial — `session show` (via `include=session_info`); `update`/`consent` still need a reauth/session-boundary flow | Partial (Phase 7) |
 | Endpoint-manager (admin) | ✅ | ✅ (`endpoint-manager` — monitored-endpoints, task-list/show/cancel/pause/resume, pause-rule, ...) | Covered (Phase 6) |
 | Endpoint set-subscription-id / my-shared-endpoint-list | ✅ | ✅ | Covered (Phase 6) |
 | `list-commands` / `version` | ✅ | ✅ | Covered (Phase 6) |

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
-	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-1
+	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-2
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-1 h1:siRyhr80d0QVdyRW7rTreLpOCgfFZgjI6x5YFfuBn7o=
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-1/go.mod h1:9JS8WLRlCun1ihEKNBw/u6NWGGsYBDFSv0cN7X3543w=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-2 h1:K5GWyHYI+8Yr8SKuaeoOwVyrO7+NILM4pa/5/MEp+fk=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-2/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=


### PR DESCRIPTION
## `session show` — completes the introspection-backed part of Python's `session`

Adds `globus session show`, matching the Python CLI: it introspects the stored
auth token with `include=session_info` and lists the identities authenticated in
your current Globus Auth session, when each authenticated, and whether MFA was
used. `-F json`/`-F unix` emit the raw `session_info`.

### Depends on globus-go-sdk v4.8.1-2 (PR #55)
Pins the v4 SDK to `v4.8.1-2`, which added `TokenIntrospection.SessionInfo`
(and, for future work, `Endpoint.GCSManagerURL`). `go.mod` bumped accordingly;
verified `GOWORK=off` build/vet/test against the published tag.

### Still deferred
`session update` / `session consent` need a reauthentication / session-boundary
flow the SDK does not yet expose — documented in `PYTHON_CLI_PARITY.md` as
partial.

### Verification
`GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues. Parity and
flat-structure tests assert `session` / `session show`.