### PR TITLE
feat: GCS/collections commands — collection + gcs (Phase 7)

### DIFF
--- a/cmd/collection.go
+++ b/cmd/collection.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/scttfrdmn/globus-go-cli/cmd/collection"
+)
+
+// getCollectionCommand returns the `collection` command group (GCSv5 collection
+// management).
+func getCollectionCommand() *cobra.Command {
+	return collection.CollectionCmd()
+}
+
+// getGCSCommand returns the `gcs` command group (GCSv5 endpoint/storage-gateway/
+// role management).
+func getGCSCommand() *cobra.Command {
+	return collection.GCSCmd()
+}

--- a/cmd/collection/client.go
+++ b/cmd/collection/client.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+
+// Package collection implements the `globus collection` and `globus gcs`
+// command trees over the v4 SDK's GCS Manager (gcs.CollectionClient).
+//
+// GCS management has a different auth model from the fixed-resource-server
+// services: the client talks to a specific endpoint's GCS Manager host (its
+// gcs_manager_url, discovered via the Transfer API), and management operations
+// require that endpoint's dynamic `manage_collections` consent — which the
+// normal `globus login` scope set does not include. getManagerClient therefore
+// (1) resolves the manager URL from the endpoint document and (2) obtains a
+// manage_collections authorizer, escalating consent (paste-code login) on first
+// use.
+package collection
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/gcs"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
+)
+
+// resolveManagerURL looks up the endpoint's GCS Manager base URL via the
+// Transfer API. Returns an error if the endpoint is not a GCSv5 endpoint (no
+// gcs_manager_url).
+func resolveManagerURL(ctx context.Context, endpointID string) (string, error) {
+	profile := viper.GetString("profile")
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to load client configuration: %w", err)
+	}
+	cfg, err := globusauth.ClientConfig(ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret, globusauth.ServiceTransfer)
+	if err != nil {
+		return "", fmt.Errorf("not logged in: %w", err)
+	}
+	tc, err := transfer.NewClient(ctx, cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to create transfer client: %w", err)
+	}
+	ep, err := tc.GetEndpoint(ctx, endpointID)
+	if err != nil {
+		return "", fmt.Errorf("failed to look up endpoint %s: %w", endpointID, err)
+	}
+	if ep.GCSManagerURL == "" {
+		return "", fmt.Errorf("endpoint %s is not a Globus Connect Server v5 endpoint (no gcs_manager_url); collection/gcs commands require GCSv5", endpointID)
+	}
+	return ep.GCSManagerURL, nil
+}
+
+// getManagerClient builds a GCS CollectionClient for managing the given
+// endpoint. It resolves the manager URL from the endpoint document and obtains
+// a manage_collections authorizer for the endpoint, escalating consent on first
+// use (a browser/paste-code login prompt).
+func getManagerClient(ctx context.Context, endpointID string) (*gcs.CollectionClient, error) {
+	managerURL, err := resolveManagerURL(ctx, endpointID)
+	if err != nil {
+		return nil, err
+	}
+
+	profile := viper.GetString("profile")
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	// Management operations use the endpoint's manage_collections scope (an
+	// endpoint scope in URN format), keyed on the endpoint ID as resource
+	// server. Escalate consent if we have no token for it yet.
+	scope := gcs.EndpointManageCollectionsScope(endpointID)
+	cfg, err := globusauth.ScopedClientConfig(ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret, endpointID, scope, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// The CollectionClient targets the endpoint's own GCS Manager; the
+	// collection ID used for its default scope requirements is the endpoint ID
+	// for management operations.
+	client, err := gcs.NewCollectionClient(ctx, managerURL, endpointID, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCS collection client: %w", err)
+	}
+	return client, nil
+}

--- a/cmd/collection/collection.go
+++ b/cmd/collection/collection.go
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package collection
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/gcs"
+)
+
+// CollectionCmd returns the collection command tree.
+//
+// Every subcommand takes the owning endpoint's ID as its first positional
+// argument: GCS Manager operations are scoped to a specific endpoint, and
+// getManagerClient resolves that endpoint's GCS Manager URL and manage_collections
+// consent from it.
+func CollectionCmd() *cobra.Command {
+	collectionCmd := &cobra.Command{
+		Use:   "collection",
+		Short: "Commands for managing Globus Connect Server collections",
+		Long: `Commands for managing collections on a Globus Connect Server v5
+endpoint's GCS Manager, including listing, showing, creating, updating,
+and deleting mapped and guest collections.
+
+Every subcommand takes the owning endpoint's ID as its first argument. The
+CLI resolves that endpoint's GCS Manager URL and escalates the endpoint's
+manage_collections consent on first use (a paste-code login prompt).`,
+	}
+
+	collectionCmd.AddCommand(
+		collectionListCmd(),
+		collectionShowCmd(),
+		collectionCreateCmd(),
+		collectionUpdateCmd(),
+		collectionDeleteCmd(),
+	)
+
+	return collectionCmd
+}
+
+// Options for collection listing and mutation.
+var (
+	collectionMappedID     string
+	collectionPageSize     int
+	collectionType         string
+	collectionDisplayName  string
+	collectionStorageGWID  string
+	collectionBasePath     string
+	collectionIdentityID   string
+	collectionPublic       bool
+	collectionDescription  string
+	collectionOrganization string
+)
+
+// collectionListCmd returns the collection list command.
+func collectionListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list ENDPOINT_ID",
+		Short: "List collections on a GCS endpoint",
+		Long: `List the collections hosted by the given endpoint's GCS Manager.
+
+Optionally filter to the guest collections of a single mapped collection.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listCollections(cmd, args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&collectionMappedID, "mapped-collection-id", "", "Filter to guest collections of this mapped collection")
+	cmd.Flags().IntVar(&collectionPageSize, "page-size", 100, "Maximum number of collections to return")
+
+	return cmd
+}
+
+// collectionShowCmd returns the collection show command.
+func collectionShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show ENDPOINT_ID COLLECTION_ID",
+		Short: "Show collection details",
+		Long:  `Show detailed information about a collection on the given endpoint's GCS Manager.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showCollection(cmd, args[0], args[1])
+		},
+	}
+}
+
+// collectionCreateCmd returns the collection create command.
+func collectionCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create ENDPOINT_ID",
+		Short: "Create a collection",
+		Long: `Create a mapped or guest collection on the given endpoint's GCS Manager.
+
+Mapped collections require --storage-gateway-id; guest collections require
+--mapped-collection-id (and typically --base-path).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return createCollection(cmd, args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&collectionType, "type", "", "Collection type: mapped or guest (required)")
+	cmd.Flags().StringVar(&collectionDisplayName, "display-name", "", "Display name for the collection (required)")
+	cmd.Flags().StringVar(&collectionStorageGWID, "storage-gateway-id", "", "Storage gateway ID (required for mapped collections)")
+	cmd.Flags().StringVar(&collectionBasePath, "base-path", "", "Collection base path")
+	cmd.Flags().StringVar(&collectionMappedID, "mapped-collection-id", "", "Mapped collection ID (for guest collections)")
+	cmd.Flags().StringVar(&collectionIdentityID, "identity-id", "", "Identity ID that owns the collection")
+	cmd.Flags().BoolVar(&collectionPublic, "public", false, "Make the collection publicly visible")
+	cmd.Flags().StringVar(&collectionDescription, "description", "", "Description of the collection")
+	cmd.Flags().StringVar(&collectionOrganization, "organization", "", "Organization for the collection")
+	_ = cmd.MarkFlagRequired("type")
+	_ = cmd.MarkFlagRequired("display-name")
+
+	return cmd
+}
+
+// collectionUpdateCmd returns the collection update command.
+func collectionUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update ENDPOINT_ID COLLECTION_ID",
+		Short: "Update a collection",
+		Long: `Update mutable fields of a collection on the given endpoint's GCS Manager.
+
+Only the fields you supply as flags are changed.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return updateCollection(cmd, args[0], args[1])
+		},
+	}
+
+	cmd.Flags().StringVar(&collectionDisplayName, "display-name", "", "New display name")
+	cmd.Flags().StringVar(&collectionDescription, "description", "", "New description")
+	cmd.Flags().StringVar(&collectionOrganization, "organization", "", "New organization")
+	cmd.Flags().BoolVar(&collectionPublic, "public", false, "Set public visibility")
+
+	return cmd
+}
+
+// collectionDeleteCmd returns the collection delete command.
+func collectionDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete ENDPOINT_ID COLLECTION_ID",
+		Short: "Delete a collection",
+		Long:  `Permanently delete a collection from the given endpoint's GCS Manager.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deleteCollection(cmd, args[0], args[1])
+		},
+	}
+}
+
+// listCollections lists the collections on an endpoint's GCS Manager.
+func listCollections(cmd *cobra.Command, endpointID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	opts := &gcs.ListCollectionsOptions{
+		MappedCollectionID: collectionMappedID,
+		PageSize:           collectionPageSize,
+	}
+
+	resp, err := client.ListCollections(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to list collections: %w", err)
+	}
+
+	// Route all formats through the shared formatter so -F (text/json/unix) and
+	// --jmespath/--jq work uniformly. For JSON, emit the raw GCS response
+	// envelope; for text/unix, a projected row set.
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+
+	if formatter.Format == output.FormatJSON {
+		return formatter.FormatOutput(resp, nil)
+	}
+
+	type collectionRow struct {
+		ID             string
+		DisplayName    string
+		Type           string
+		StorageGateway string
+		Public         bool
+	}
+	rows := make([]collectionRow, 0, len(resp.Data))
+	for _, c := range resp.Data {
+		rows = append(rows, collectionRow{
+			ID: c.ID, DisplayName: c.DisplayName, Type: c.CollectionType,
+			StorageGateway: c.StorageGatewayID, Public: c.PubliclyVisible,
+		})
+	}
+	return formatter.FormatOutput(rows, []string{"ID", "DisplayName", "Type", "StorageGateway", "Public"})
+}
+
+// showCollection shows details for a single collection.
+func showCollection(cmd *cobra.Command, endpointID, collectionID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	col, err := client.GetCollection(ctx, collectionID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get collection: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(col, nil)
+	}
+
+	fmt.Println("Collection Details:")
+	fmt.Printf("  ID:                  %s\n", col.ID)
+	fmt.Printf("  Display Name:        %s\n", col.DisplayName)
+	fmt.Printf("  Type:                %s\n", col.CollectionType)
+	fmt.Printf("  Public:              %t\n", col.PubliclyVisible)
+	fmt.Printf("  High Assurance:      %t\n", col.HighAssurance)
+	if col.StorageGatewayID != "" {
+		fmt.Printf("  Storage Gateway:     %s\n", col.StorageGatewayID)
+	}
+	if col.MappedCollectionID != "" {
+		fmt.Printf("  Mapped Collection:   %s\n", col.MappedCollectionID)
+	}
+	if col.Organization != "" {
+		fmt.Printf("  Organization:        %s\n", col.Organization)
+	}
+	if col.ContactEmail != "" {
+		fmt.Printf("  Contact Email:       %s\n", col.ContactEmail)
+	}
+	if col.DomainName != "" {
+		fmt.Printf("  Domain Name:         %s\n", col.DomainName)
+	}
+	if col.HTTPSURL != "" {
+		fmt.Printf("  HTTPS URL:           %s\n", col.HTTPSURL)
+	}
+
+	return nil
+}
+
+// createCollection creates a collection, setting only the fields provided.
+func createCollection(cmd *cobra.Command, endpointID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	// Build the document from the provided fields only. DataType is left empty:
+	// the SDK sets the appropriate default version.
+	doc := &gcs.CollectionDocument{
+		CollectionType: collectionType,
+		DisplayName:    collectionDisplayName,
+	}
+	if collectionStorageGWID != "" {
+		doc.StorageGatewayID = collectionStorageGWID
+	}
+	if collectionBasePath != "" {
+		doc.CollectionBasePath = collectionBasePath
+	}
+	if collectionMappedID != "" {
+		doc.MappedCollectionID = collectionMappedID
+	}
+	if collectionIdentityID != "" {
+		doc.IdentityID = collectionIdentityID
+	}
+	if collectionOrganization != "" {
+		doc.Organization = collectionOrganization
+	}
+	if cmd.Flags().Changed("public") {
+		public := collectionPublic
+		doc.Public = &public
+	}
+	if cmd.Flags().Changed("description") {
+		desc := collectionDescription
+		doc.Description = &desc
+	}
+
+	col, err := client.CreateCollection(ctx, doc)
+	if err != nil {
+		return fmt.Errorf("failed to create collection: %w", err)
+	}
+
+	fmt.Printf("Created collection %s (%s)\n", col.ID, col.DisplayName)
+	return nil
+}
+
+// updateCollection updates a collection with only the provided fields.
+func updateCollection(cmd *cobra.Command, endpointID, collectionID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	doc := &gcs.CollectionDocument{}
+	if cmd.Flags().Changed("display-name") {
+		doc.DisplayName = collectionDisplayName
+	}
+	if cmd.Flags().Changed("organization") {
+		doc.Organization = collectionOrganization
+	}
+	if cmd.Flags().Changed("public") {
+		public := collectionPublic
+		doc.Public = &public
+	}
+	if cmd.Flags().Changed("description") {
+		desc := collectionDescription
+		doc.Description = &desc
+	}
+
+	if _, err := client.UpdateCollection(ctx, collectionID, doc); err != nil {
+		return fmt.Errorf("failed to update collection: %w", err)
+	}
+
+	fmt.Printf("Updated collection %s\n", collectionID)
+	return nil
+}
+
+// deleteCollection deletes a collection.
+func deleteCollection(cmd *cobra.Command, endpointID, collectionID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	if err := client.DeleteCollection(ctx, collectionID); err != nil {
+		return fmt.Errorf("failed to delete collection: %w", err)
+	}
+
+	fmt.Printf("Deleted collection %s\n", collectionID)
+	return nil
+}

--- a/cmd/collection/gcs.go
+++ b/cmd/collection/gcs.go
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package collection
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/gcs"
+)
+
+// GCSCmd returns the gcs command tree for endpoint-level GCS Manager admin.
+//
+// Every subcommand takes the owning endpoint's ID as its first positional
+// argument, used by getManagerClient to resolve the GCS Manager URL and
+// manage_collections consent.
+func GCSCmd() *cobra.Command {
+	gcsCmd := &cobra.Command{
+		Use:   "gcs",
+		Short: "Commands for administering a Globus Connect Server endpoint",
+		Long: `Endpoint-level administration of a Globus Connect Server v5 endpoint's
+GCS Manager, including server info, storage gateways, and role assignments.
+
+Every subcommand takes the endpoint's ID as its first argument.`,
+	}
+
+	gcsCmd.AddCommand(
+		gcsInfoCmd(),
+		gcsStorageGatewayCmd(),
+		gcsRoleCmd(),
+	)
+
+	return gcsCmd
+}
+
+// Options for role creation.
+var (
+	rolePrincipal  string
+	roleName       string
+	roleCollection string
+)
+
+// gcsInfoCmd returns the gcs info command.
+func gcsInfoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "info ENDPOINT_ID",
+		Short: "Show GCS Manager info",
+		Long:  `Show the GCS Manager info document (client ID and endpoint ID) for the given endpoint.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return gcsInfo(cmd, args[0])
+		},
+	}
+}
+
+// gcsStorageGatewayCmd returns the storage-gateway subgroup.
+func gcsStorageGatewayCmd() *cobra.Command {
+	sgCmd := &cobra.Command{
+		Use:   "storage-gateway",
+		Short: "Commands for managing storage gateways",
+		Long:  `List and show storage gateways on the given endpoint's GCS Manager.`,
+	}
+
+	sgCmd.AddCommand(
+		storageGatewayListCmd(),
+		storageGatewayShowCmd(),
+	)
+
+	return sgCmd
+}
+
+// storageGatewayListCmd returns the storage-gateway list command.
+func storageGatewayListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list ENDPOINT_ID",
+		Short: "List storage gateways",
+		Long:  `List the storage gateways on the given endpoint's GCS Manager.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listStorageGateways(cmd, args[0])
+		},
+	}
+}
+
+// storageGatewayShowCmd returns the storage-gateway show command.
+func storageGatewayShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show ENDPOINT_ID STORAGE_GATEWAY_ID",
+		Short: "Show storage gateway details",
+		Long:  `Show detailed information about a storage gateway on the given endpoint's GCS Manager.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showStorageGateway(cmd, args[0], args[1])
+		},
+	}
+}
+
+// gcsRoleCmd returns the role subgroup.
+func gcsRoleCmd() *cobra.Command {
+	roleCmd := &cobra.Command{
+		Use:   "role",
+		Short: "Commands for managing role assignments",
+		Long:  `List, show, create, and delete role assignments on the given endpoint's GCS Manager.`,
+	}
+
+	roleCmd.AddCommand(
+		roleListCmd(),
+		roleShowCmd(),
+		roleCreateCmd(),
+		roleDeleteCmd(),
+	)
+
+	return roleCmd
+}
+
+// roleListCmd returns the role list command.
+func roleListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list ENDPOINT_ID",
+		Short: "List role assignments",
+		Long:  `List the role assignments on the given endpoint's GCS Manager.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listRoles(cmd, args[0])
+		},
+	}
+}
+
+// roleShowCmd returns the role show command.
+func roleShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show ENDPOINT_ID ROLE_ID",
+		Short: "Show role assignment details",
+		Long:  `Show detailed information about a role assignment on the given endpoint's GCS Manager.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showRole(cmd, args[0], args[1])
+		},
+	}
+}
+
+// roleCreateCmd returns the role create command.
+func roleCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create ENDPOINT_ID",
+		Short: "Create a role assignment",
+		Long: `Create a role assignment on the given endpoint's GCS Manager.
+
+Omit --collection to assign an endpoint-level role.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return createRole(cmd, args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&rolePrincipal, "principal", "", "Principal (identity or group URN) to assign the role to (required)")
+	cmd.Flags().StringVar(&roleName, "role", "", "Role name (owner, administrator, access_manager, activity_manager, activity_monitor) (required)")
+	cmd.Flags().StringVar(&roleCollection, "collection", "", "Collection ID for a collection-level role (omit for an endpoint role)")
+	_ = cmd.MarkFlagRequired("principal")
+	_ = cmd.MarkFlagRequired("role")
+
+	return cmd
+}
+
+// roleDeleteCmd returns the role delete command.
+func roleDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete ENDPOINT_ID ROLE_ID",
+		Short: "Delete a role assignment",
+		Long:  `Delete a role assignment from the given endpoint's GCS Manager.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deleteRole(cmd, args[0], args[1])
+		},
+	}
+}
+
+// gcsInfo shows the GCS Manager info document.
+func gcsInfo(cmd *cobra.Command, endpointID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	info, err := client.GetGCSInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get GCS info: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(info, nil)
+	}
+
+	type infoRow struct {
+		ClientID   string
+		EndpointID string
+	}
+	return formatter.FormatOutput(
+		[]infoRow{{ClientID: info.ClientID, EndpointID: info.EndpointID}},
+		[]string{"ClientID", "EndpointID"},
+	)
+}
+
+// listStorageGateways lists the storage gateways on an endpoint's GCS Manager.
+func listStorageGateways(cmd *cobra.Command, endpointID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.GetStorageGatewayList(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list storage gateways: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+
+	if formatter.Format == output.FormatJSON {
+		return formatter.FormatOutput(resp, nil)
+	}
+
+	type gatewayRow struct {
+		ID            string
+		DisplayName   string
+		ConnectorID   string
+		HighAssurance bool
+	}
+	rows := make([]gatewayRow, 0, len(resp.Data))
+	for _, g := range resp.Data {
+		rows = append(rows, gatewayRow{
+			ID: g.ID, DisplayName: g.DisplayName,
+			ConnectorID: g.ConnectorID, HighAssurance: g.HighAssurance,
+		})
+	}
+	return formatter.FormatOutput(rows, []string{"ID", "DisplayName", "ConnectorID", "HighAssurance"})
+}
+
+// showStorageGateway shows details for a single storage gateway.
+func showStorageGateway(cmd *cobra.Command, endpointID, storageGatewayID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	gw, err := client.GetStorageGateway(ctx, storageGatewayID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get storage gateway: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(gw, nil)
+	}
+
+	fmt.Println("Storage Gateway Details:")
+	fmt.Printf("  ID:              %s\n", gw.ID)
+	fmt.Printf("  Display Name:    %s\n", gw.DisplayName)
+	fmt.Printf("  Connector ID:    %s\n", gw.ConnectorID)
+	fmt.Printf("  High Assurance:  %t\n", gw.HighAssurance)
+	fmt.Printf("  Require MFA:     %t\n", gw.RequireMFA)
+
+	return nil
+}
+
+// listRoles lists the role assignments on an endpoint's GCS Manager.
+func listRoles(cmd *cobra.Command, endpointID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.GetRoleList(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list roles: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+
+	if formatter.Format == output.FormatJSON {
+		return formatter.FormatOutput(resp, nil)
+	}
+
+	type roleRow struct {
+		ID         string
+		Principal  string
+		Role       string
+		Collection string
+	}
+	rows := make([]roleRow, 0, len(resp.Data))
+	for _, r := range resp.Data {
+		collection := ""
+		if r.Collection != nil {
+			collection = *r.Collection
+		}
+		rows = append(rows, roleRow{
+			ID: r.ID, Principal: r.Principal, Role: r.Role, Collection: collection,
+		})
+	}
+	return formatter.FormatOutput(rows, []string{"ID", "Principal", "Role", "Collection"})
+}
+
+// showRole shows details for a single role assignment.
+func showRole(cmd *cobra.Command, endpointID, roleID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	role, err := client.GetRole(ctx, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to get role: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(role, nil)
+	}
+
+	collection := "(endpoint)"
+	if role.Collection != nil {
+		collection = *role.Collection
+	}
+	fmt.Println("Role Details:")
+	fmt.Printf("  ID:          %s\n", role.ID)
+	fmt.Printf("  Principal:   %s\n", role.Principal)
+	fmt.Printf("  Role:        %s\n", role.Role)
+	fmt.Printf("  Collection:  %s\n", collection)
+
+	return nil
+}
+
+// createRole creates a role assignment.
+func createRole(cmd *cobra.Command, endpointID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	doc := &gcs.GCSRoleDocument{
+		Principal: rolePrincipal,
+		Role:      roleName,
+	}
+	if roleCollection != "" {
+		doc.Collection = roleCollection
+	}
+
+	role, err := client.CreateRole(ctx, doc)
+	if err != nil {
+		return fmt.Errorf("failed to create role: %w", err)
+	}
+
+	fmt.Printf("Created role %s (%s for %s)\n", role.ID, role.Role, role.Principal)
+	return nil
+}
+
+// deleteRole deletes a role assignment.
+func deleteRole(cmd *cobra.Command, endpointID, roleID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+
+	if err := client.DeleteRole(ctx, roleID); err != nil {
+		return fmt.Errorf("failed to delete role: %w", err)
+	}
+
+	fmt.Printf("Deleted role %s\n", roleID)
+	return nil
+}

--- a/cmd/parity_test.go
+++ b/cmd/parity_test.go
@@ -79,6 +79,9 @@ func TestCommandParity(t *testing.T) {
 		"api transfer", "api auth",
 		// Session.
 		"session show",
+		// GCSv5 collections + manager admin.
+		"collection list", "collection show", "collection create", "collection delete",
+		"gcs info", "gcs storage-gateway list", "gcs role list", "gcs role create",
 		// Meta commands.
 		"list-commands", "version",
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -248,6 +248,8 @@ func addServiceCommands() {
 		getFlowsCommand(),
 		getComputeCommand(),
 		getEndpointManagerCommand(),
+		getCollectionCommand(),
+		getGCSCommand(),
 		getAPICommand(),
 		getConfigCommand(),
 		getListCommandsCommand(),

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -80,6 +80,7 @@ func TestFlatCommandStructure(t *testing.T) {
 		"ls", "mkdir", "rm", "rename", "stat", "delete", "transfer", "task", "endpoint",
 		"bookmark", "tunnel", "stream-access-point", "endpoint-manager",
 		"group", "search", "flows", "timer", "compute", "api", "config",
+		"collection", "gcs",
 		"list-commands", "version",
 	}
 	for _, name := range wantTopLevel {

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -60,7 +60,7 @@ device-code flow and `identities lookup` performs a real `GetIdentities` call
 | Endpoint roles | ✅ (create/delete/list/show) | ✅ (`endpoint role list/show/create/delete`) | Covered (Phase 4) |
 | Endpoint permissions (ACLs) | ✅ (5) | ✅ (`endpoint permission list/show/create/update/delete`) | Covered (Phase 4) |
 | Bookmarks | ✅ (5) | ✅ (`bookmark list/show/create/rename/delete`) | Covered (Phase 4) |
-| Collections / GCS management | ✅ (`collection`, `gcs`, 32 cmds) | ❌ none | Blocked — SDK lacks endpoint GCS-manager URL + per-collection consent (see below) |
+| Collections / GCS management | ✅ (`collection`, `gcs`, 32 cmds) | ✅ core set — `collection list/show/create/update/delete`, `gcs info`, `gcs storage-gateway list/show`, `gcs role list/show/create/delete` | Covered (Phase 7) |
 | GCP (Connect Personal) | ✅ (6) | ❌ none | Gap (no SDK support) |
 | Streams / tunnels | ✅ (8) | ✅ (`tunnel list/show/create/update/delete/events`, `stream-access-point list/show`) | Covered (Phase 5) |
 | Search (index/query/ingest/task/role/subject) | ✅ (14) | ✅ comparable | Covered |
@@ -111,20 +111,20 @@ Still available in the SDK but not yet wired:
 - **Streams / tunnels** — DONE (Phase 5). The v4 transfer client's
   tunnel/stream-access-point methods now back real `tunnel` and
   `stream-access-point` commands (the "unavailable" stubs are gone).
-- **GCS / collections management** (`collection`, `gcs`, ~32 commands) —
-  **still blocked**, and NOT merely CLI wiring. The v4 SDK's `gcs.CollectionClient`
-  needs two things the rest of the CLI doesn't have:
-  1. the endpoint's **GCS Manager URL** (`https://<gcs-host>/api`), which is not
-     exposed on the v4 SDK's transfer `Endpoint` struct — there is no field to
-     read it from, so the client address can't be constructed from a collection
-     ID alone; and
-  2. **dynamic per-collection consent** — each collection has its own
-     `.../<collection-id>/https` and `.../data_access` scopes, but the CLI's
-     GlobusApp login requests only a fixed scope set, so `GetAuthorizer` has no
-     token for a given collection's data-access scope.
-  Wiring `collection`/`gcs` needs SDK support to surface the manager URL (e.g. on
-  the endpoint document) and a consent/scope-escalation path in `pkg/globusauth`.
-  Deferred to a future phase (tracked as SDK work).
+- **GCS / collections management** (`collection`, `gcs`) — DONE (Phase 7). The
+  two former blockers were resolved with SDK support:
+  1. the endpoint's **GCS Manager URL** is now on the transfer `Endpoint`
+     (`gcs_manager_url`, SDK v4.8.1-2), so the CLI resolves the manager address
+     from the endpoint ID via the Transfer API; and
+  2. **dynamic consent escalation** — `pkg/globusauth.ScopedClientConfig` builds
+     a GlobusApp for an endpoint/collection's dynamic scope and runs a consent
+     login on first use. Management uses the endpoint's `manage_collections`
+     scope (`gcs.EndpointManageCollectionsScope`, SDK v4.8.1-3).
+  `collection list/show/create/update/delete` and `gcs info` +
+  `storage-gateway`/`role` subcommands are wired. Each takes the owning
+  `ENDPOINT_ID` as its first argument. Data-plane operations that need a
+  collection's `data_access`/`https` scope (e.g. GCS-hosted file listing) are a
+  possible future addition using the same consent-escalation helper.
 - **GCP (Globus Connect Personal)** — local-agent management; not an SDK API
   (out of scope).
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
-	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-2
+	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-3
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-1 h1:siRyhr80d0QVdyRW7rTreLpOCgfFZg
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-1/go.mod h1:9JS8WLRlCun1ihEKNBw/u6NWGGsYBDFSv0cN7X3543w=
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-2 h1:K5GWyHYI+8Yr8SKuaeoOwVyrO7+NILM4pa/5/MEp+fk=
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-2/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-3 h1:LVuSPPWNZHPu4k/XcByNHeA0dJJkEypZ/IGtopg122A=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-3/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=

--- a/pkg/globusauth/app.go
+++ b/pkg/globusauth/app.go
@@ -292,3 +292,61 @@ func StoreTokens(profile string, now time.Time, tokens ...StoredToken) error {
 	}
 	return nil
 }
+
+// ScopedApp builds a UserApp registered for a single dynamic (resourceServer,
+// scope) pair rather than the fixed service registry. Used for GCS, whose
+// scopes are keyed on a specific endpoint or collection ID rather than a
+// well-known service resource server.
+func ScopedApp(profile, clientID, clientSecret, resourceServer, scope string) (*app.UserApp, error) {
+	if clientID == "" {
+		clientID = DefaultClientID
+	}
+	path, err := tokenStoragePath(profile)
+	if err != nil {
+		return nil, err
+	}
+	store, err := tokenstorage.NewJSONTokenStorageWithNamespace(path, "globus-cli")
+	if err != nil {
+		return nil, fmt.Errorf("cannot open token storage: %w", err)
+	}
+	userApp, err := app.NewUserApp(clientID, clientSecret, &app.AppConfig{
+		TokenStorage:         store,
+		RequestRefreshTokens: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	userApp.AddScopeRequirements(resourceServer, scope)
+	return userApp, nil
+}
+
+// ScopedClientConfig returns a *core.Config authorized for a dynamic
+// (resourceServer, scope) pair from the profile's stored tokens — used to build
+// a GCS CollectionClient. If no token is stored for that resource server and
+// allowConsent is true, it runs a consent login (the paste-code flow) to obtain
+// one; otherwise it returns an error advising the user to run the login. The
+// scope determines what the consent grants (an endpoint's manage_collections or
+// a collection's data_access).
+func ScopedClientConfig(ctx context.Context, profile, clientID, clientSecret, resourceServer, scope string, allowConsent bool) (*core.Config, error) {
+	userApp, err := ScopedApp(profile, clientID, clientSecret, resourceServer, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	authz, err := userApp.GetAuthorizer(ctx, resourceServer)
+	if err != nil {
+		if !allowConsent {
+			return nil, fmt.Errorf("%w (run 'globus login' or retry with consent)", err)
+		}
+		// No stored token for this resource server: escalate consent.
+		if lerr := userApp.Login(ctx); lerr != nil {
+			return nil, fmt.Errorf("consent login failed: %w", lerr)
+		}
+		authz, err = userApp.GetAuthorizer(ctx, resourceServer)
+		if err != nil {
+			return nil, fmt.Errorf("no token after consent for %q: %w", resourceServer, err)
+		}
+	}
+
+	return &core.Config{Authorizer: authz, Scopes: []string{scope}}, nil
+}


### PR DESCRIPTION
## Phase 7 — GCS/collections: the last major parity gap

Adds the `collection` and `gcs` command trees over the v4 `gcs.CollectionClient`.
Requires v4 SDK **v4.8.1-3** (bumped in go.mod), which supplied the two pieces
that were blocking this: `Endpoint.gcs_manager_url` (v4.8.1-2) and
`gcs.EndpointManageCollectionsScope` (v4.8.1-3).

### The auth model (what was blocked)
GCS management talks to a *specific endpoint's* GCS Manager host and needs that
endpoint's dynamic `manage_collections` consent — which the standard `globus
login` scope set omits. Resolved with:
- **`pkg/globusauth.ScopedClientConfig`** — builds a GlobusApp for a dynamic
  `(resourceServer, scope)` pair and runs a consent (paste-code) login on first
  use, returning an authorizer.
- **`cmd/collection/client.go getManagerClient(ctx, endpointID)`** — resolves
  the endpoint's `gcs_manager_url` via the Transfer API, then builds a
  `gcs.CollectionClient` authorized with the endpoint's `manage_collections`
  scope, escalating consent as needed.

### Commands (each takes the owning `ENDPOINT_ID` first)
- `collection list/show/create/update/delete`
- `gcs info`; `gcs storage-gateway list/show`; `gcs role list/show/create/delete`

Non-GCSv5 endpoints get a clear error. Output routes through the shared
formatter (`-F`/`--jq`). Data-plane ops (a collection's `data_access`/`https`
scope) are a possible future addition using the same escalation helper.

### Verification
`GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues; parity +
flat-structure tests assert the new commands; trees render.