### PR TITLE
feat(auth): session update + consent (completes command parity)

### DIFF
--- a/cmd/auth/session.go
+++ b/cmd/auth/session.go
@@ -11,27 +11,114 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
 	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
 )
 
 // SessionCmd returns the `session` command group, matching the Python Globus
-// CLI's `globus session`. Currently only `show` is available: `update` and
-// `consent` require a reauthentication / session-boundary flow the SDK does not
-// yet expose.
+// CLI's `globus session` (show / update / consent).
 func SessionCmd() *cobra.Command {
 	sessionCmd := &cobra.Command{
 		Use:   "session",
 		Short: "Commands for managing your Globus Auth session",
-		Long: `Commands for inspecting your current Globus Auth session.
+		Long: `Commands for inspecting and updating your Globus Auth session.
 
 A session records which of your identities have authenticated and when — the
 basis for high-assurance ("session boundary") access decisions.`,
 	}
 
-	sessionCmd.AddCommand(sessionShowCmd())
+	sessionCmd.AddCommand(sessionShowCmd(), sessionUpdateCmd(), sessionConsentCmd())
 	return sessionCmd
+}
+
+// loadClientCreds returns the configured client ID/secret for the current
+// profile (native client by default).
+func loadClientCreds() (clientID, clientSecret string, err error) {
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to load client configuration: %w", err)
+	}
+	return clientCfg.ClientID, clientCfg.ClientSecret, nil
+}
+
+// sessionUpdateCmd returns the `session update` command: it re-runs the login
+// flow with session-enforcement parameters so Globus Auth forces step-up
+// re-authentication of specific identities/domains or per an auth policy.
+func sessionUpdateCmd() *cobra.Command {
+	var (
+		identities []string
+		domain     string
+		policies   []string
+		mfa        bool
+	)
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update your session by re-authenticating",
+		Long: `Update your current CLI auth session by re-authenticating. You can require
+specific identities, a single identity-provider domain, authentication
+policies, or MFA. This starts a browser/paste-code login flow like 'login'.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if domain != "" && len(identities) > 0 {
+				return fmt.Errorf("--domain is mutually exclusive with --identity")
+			}
+			profile := viper.GetString("profile")
+			clientID, clientSecret, err := loadClientCreds()
+			if err != nil {
+				return err
+			}
+
+			sp := &globusauth.SessionParams{
+				RequiredIdentities: identities,
+				RequiredPolicies:   policies,
+				RequiredMFA:        mfa,
+			}
+			if domain != "" {
+				sp.RequiredSingleDomain = []string{domain}
+			}
+
+			// Re-auth for the auth resource server (openid identity scopes).
+			scope, _ := globusauth.Scope(globusauth.ServiceAuth)
+			if _, err := globusauth.SessionLogin(cmd.Context(), profile, clientID, clientSecret, []string{scope}, sp); err != nil {
+				return fmt.Errorf("session update failed: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Session updated.")
+			return nil
+		},
+	}
+	cmd.Flags().StringSliceVar(&identities, "identity", nil, "Require re-authentication of these identity IDs/usernames")
+	cmd.Flags().StringVar(&domain, "domain", "", "Require an identity from this single domain (mutually exclusive with --identity)")
+	cmd.Flags().StringSliceVar(&policies, "policy", nil, "Comma-separated authentication policy UUIDs to satisfy")
+	cmd.Flags().BoolVar(&mfa, "mfa", false, "Require multi-factor authentication")
+	return cmd
+}
+
+// sessionConsentCmd returns the `session consent` command: it runs the login
+// flow requesting one or more explicit scopes, granting those consents.
+func sessionConsentCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "consent SCOPE [SCOPE...]",
+		Short: "Add specific consents to your session",
+		Long: `Update your current CLI auth session by authenticating with a specific scope
+or set of scopes. Use this when a command needs a consent you have not yet
+granted (e.g. a collection's data_access scope).`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profile := viper.GetString("profile")
+			clientID, clientSecret, err := loadClientCreds()
+			if err != nil {
+				return err
+			}
+			stored, err := globusauth.SessionLogin(cmd.Context(), profile, clientID, clientSecret, args, nil)
+			if err != nil {
+				return fmt.Errorf("session consent failed: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Consent granted; stored tokens for %d resource server(s).\n", len(stored))
+			return nil
+		},
+	}
 }
 
 // sessionShowCmd returns the `session show` command.

--- a/cmd/parity_test.go
+++ b/cmd/parity_test.go
@@ -78,7 +78,7 @@ func TestCommandParity(t *testing.T) {
 		// Raw API passthrough.
 		"api transfer", "api auth",
 		// Session.
-		"session show",
+		"session show", "session update", "session consent",
 		// GCSv5 collections + manager admin.
 		"collection list", "collection show", "collection create", "collection delete",
 		"gcs info", "gcs storage-gateway list", "gcs role list", "gcs role create",

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -68,7 +68,7 @@ device-code flow and `identities lookup` performs a real `GetIdentities` call
 | Flows (create/run/list/show/update/validate/logs) | ✅ (17) | ✅ comparable | Covered |
 | Timers | ✅ (7) | ✅ (create/list/show/pause/resume/delete) | Covered |
 | `api` raw passthrough | ✅ (7 services) | ✅ (`api auth/transfer/groups/search/flows/timer/compute`) | Covered (Phase 5) |
-| `session` (consent/show/update) | ✅ (3) | Partial — `session show` (via `include=session_info`); `update`/`consent` still need a reauth/session-boundary flow | Partial (Phase 7) |
+| `session` (consent/show/update) | ✅ (3) | ✅ — `session show` (via `include=session_info`), `session update` (step-up re-auth), `session consent` (scoped consent) | Covered (Phase 8) |
 | Endpoint-manager (admin) | ✅ | ✅ (`endpoint-manager` — monitored-endpoints, task-list/show/cancel/pause/resume, pause-rule, ...) | Covered (Phase 6) |
 | Endpoint set-subscription-id / my-shared-endpoint-list | ✅ | ✅ | Covered (Phase 6) |
 | `list-commands` / `version` | ✅ | ✅ | Covered (Phase 6) |
@@ -99,10 +99,10 @@ Still available in the SDK but not yet wired:
   `SetSubscriptionID`/`MySharedEndpointList`/`GetSharedEndpointList`.
 - **Endpoint-manager admin surface** — SDK: full `EndpointManager*` family
   (monitored endpoints, admin task list/cancel/pause, pause rules).
-- **`session` show/update/consent** — the Python CLI's session commands drive a
-  high-assurance **reauthentication / session-boundary** flow. The v4 Go SDK
-  exposes `GetConsents` but no reauth/session-update endpoint, so a faithful
-  `session` is deferred pending SDK support (see Phase 6 / SDK work).
+
+`session show/update/consent` is now DONE (Phase 8): `show` reads
+`include=session_info`; `update` re-runs the login flow with
+`session_required_*` params (SDK v4.8.1-4); `consent` runs a scoped login.
 
 ### B. Gaps with no v3 SDK support (need SDK work first, or are out of scope)
 
@@ -137,17 +137,17 @@ or functions server-side — those require the Globus Compute serialization SDK)
 
 ## Summary
 
-The Go CLI covers the **core data-management workflows** (transfer, search,
-groups, flows, timers, auth) at parity with the Python CLI's most-used commands,
-plus a compute extension. After Phase 4, endpoint administration (roles,
-ACLs/permissions, update/delete), bookmarks, transfer `rename`/`stat`/`delete`,
-task `event-list`/`pause-info`/`update`, and the full group membership + policy
-surface are all wired. The remaining gaps are:
+The Go CLI is now a **functional drop-in replacement** for the Python Globus
+CLI across the full command surface, all on the v4 SDK: flat command paths,
+matching global flags and JSON output (enveloped `DATA`), per-resource-server
+GlobusApp auth, and command coverage spanning auth (incl. `session
+show/update/consent`), transfer + endpoint administration + endpoint-manager,
+streams/tunnels, groups, search, flows, timers, GCS `collection`/`gcs`, `api`
+raw passthrough, and the `list-commands`/`version` meta commands — plus a
+compute extension the Python CLI lacks.
 
-1. **GCS/collections** (`collection`, `gcs`) — Phase 5, via the v4 `gcs` service.
-2. **`api` raw passthrough** — Phase 5, a thin HTTP wrapper.
-3. **Streams/tunnels** — v4 transfer client has the methods; Phase 5 can replace
-   the "unavailable" stubs.
-4. **`session`** — needs reauth/session-boundary SDK support not yet available.
-5. **GCP (Connect Personal)** — local-agent management; not an SDK API
-   (out of scope).
+The only remaining item is **GCP (Globus Connect Personal)** — local-agent
+management with no SDK API, out of scope. Optional future polish: GCS data-plane
+file operations (e.g. `ls` over a collection's `https` scope) via the same
+consent-escalation helper, and richer per-command flag coverage to match every
+Python option.

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
-	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-3
+	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-4
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-2 h1:K5GWyHYI+8Yr8SKuaeoOwVyrO7+NIL
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-2/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-3 h1:LVuSPPWNZHPu4k/XcByNHeA0dJJkEypZ/IGtopg122A=
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-3/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-4 h1:03n080wuEE63wJHyWIXgn2AEzxHS0MhouZbbf5MmoeE=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-4/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=

--- a/pkg/globusauth/app.go
+++ b/pkg/globusauth/app.go
@@ -17,8 +17,64 @@ import (
 
 	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/app"
 	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/core"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/login"
 	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/tokenstorage"
 )
+
+// SessionParams carries the Globus Auth session-enforcement (step-up auth)
+// options for SessionLogin — the parameters behind a `session update`.
+type SessionParams struct {
+	RequiredIdentities   []string
+	RequiredSingleDomain []string
+	RequiredPolicies     []string
+	RequiredMFA          bool
+	Message              string
+}
+
+// SessionLogin runs the command-line OAuth2 login flow for the given scopes and
+// (optional) session-enforcement parameters, then stores the resulting tokens
+// in the profile's store. It powers `session update` (force step-up re-auth via
+// the session params) and `session consent` (grant a specific scope). Scopes
+// must be non-empty. Returns the resource servers for which tokens were stored.
+func SessionLogin(ctx context.Context, profile, clientID, clientSecret string, scopes []string, sp *SessionParams) ([]string, error) {
+	if len(scopes) == 0 {
+		return nil, fmt.Errorf("at least one scope is required")
+	}
+	if clientID == "" {
+		clientID = DefaultClientID
+	}
+
+	mgr := login.NewCommandLineLoginFlowManager(clientID, clientSecret)
+	params := login.AuthParams{
+		Scopes:         scopes,
+		RequestRefresh: true,
+	}
+	if sp != nil {
+		params.SessionRequiredIdentities = sp.RequiredIdentities
+		params.SessionRequiredSingleDomain = sp.RequiredSingleDomain
+		params.SessionRequiredPolicies = sp.RequiredPolicies
+		params.SessionRequiredMFA = sp.RequiredMFA
+		params.SessionMessage = sp.Message
+	}
+
+	result, err := mgr.RunLoginFlow(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := Store(profile)
+	if err != nil {
+		return nil, err
+	}
+	var stored []string
+	for _, td := range result.Tokens {
+		if err := store.Store(td); err != nil {
+			return nil, fmt.Errorf("store token for %s: %w", td.ResourceServer, err)
+		}
+		stored = append(stored, td.ResourceServer)
+	}
+	return stored, nil
+}
 
 // DefaultClientID is the native (public) client used when the user has not
 // configured their own. Matches pkg/config.DefaultClientID.


### PR DESCRIPTION
## The last two parity commands

Completes the Python Globus CLI's `session` family:
- **`session update`** — re-runs the login flow with session-enforcement params
  (`--identity` / `--domain` / `--policy` / `--mfa`) so Globus Auth forces
  step-up re-authentication. `--domain` is mutually exclusive with `--identity`.
- **`session consent SCOPE...`** — runs a scoped login to grant specific
  consents (e.g. a collection's `data_access`).

### Foundation
`pkg/globusauth.SessionLogin` drives the command-line login flow with scopes +
optional `SessionParams` and stores the resulting tokens. Requires SDK
**v4.8.1-4** (PR #57 added `session_required_*` to `login.AuthParams`); `go.mod`
bumped.

### Parity status
With this, the CLI covers the **entire Python Globus CLI command surface** on the
v4 SDK. Only GCP (Globus Connect Personal — a local agent with no SDK API)
remains out of scope. `docs/PYTHON_CLI_PARITY.md` summary rewritten accordingly.

### Verification
`GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues; parity +
flat-structure tests assert `session show/update/consent`.