### PR TITLE
chore: implement remaining stubs; drop stale v3-SDK references

### DIFF
--- a/cmd/flows/run_delete.go
+++ b/cmd/flows/run_delete.go
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
-
-// NOTE: This command is a placeholder because the Go SDK v3.65.0-1 does not
-// yet support deleting flow runs.
-
 package flows
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -15,17 +14,10 @@ import (
 // RunDeleteCmd represents the flows run delete command
 var RunDeleteCmd = &cobra.Command{
 	Use:   "delete RUN_ID",
-	Short: "Delete a flow run (not yet supported)",
+	Short: "Delete a flow run",
 	Long: `Delete a flow run and its associated data.
 
-NOTE: This command is not yet fully implemented because the Go SDK v3.65.0-1
-does not support deleting flow runs.
-
-You can use the Globus web interface or Python CLI to delete runs:
-  - Web interface: https://app.globus.org
-  - Python CLI: globus flows run delete RUN_ID
-
-Examples (when supported):
+Examples:
   # Delete a run
   globus flows run delete RUN_ID`,
 	Args: cobra.ExactArgs(1),
@@ -33,9 +25,20 @@ Examples (when supported):
 }
 
 func runFlowsRunDelete(cmd *cobra.Command, args []string) error {
-	return fmt.Errorf("run deletion is not yet available in SDK v3.65.0-1\n" +
-		"You can delete runs using:\n" +
-		"  1. The Globus web interface (https://app.globus.org)\n" +
-		"  2. The Python Globus CLI: globus flows run delete\n\n" +
-		"The Go SDK will add run deletion support in a future release.")
+	runID := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if _, err := flowsClient.DeleteRun(ctx, runID); err != nil {
+		return fmt.Errorf("error deleting run: %w", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "Run %s deleted.\n", runID)
+	return nil
 }

--- a/cmd/flows/run_resume.go
+++ b/cmd/flows/run_resume.go
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
-
-// NOTE: This command is a placeholder because the Go SDK v3.65.0-1 does not
-// yet support resuming flow runs.
-
 package flows
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -15,27 +14,32 @@ import (
 // RunResumeCmd represents the flows run resume command
 var RunResumeCmd = &cobra.Command{
 	Use:   "resume RUN_ID",
-	Short: "Resume a flow run (not yet supported)",
-	Long: `Resume a paused or failed flow run.
+	Short: "Resume a flow run",
+	Long: `Resume a paused or inactive flow run.
 
-NOTE: This command is not yet fully implemented because the Go SDK v3.65.0-1
-does not support resuming flow runs.
-
-You can use the Globus web interface or Python CLI to resume runs:
-  - Web interface: https://app.globus.org
-  - Python CLI: globus flows run resume RUN_ID
-
-Examples (when supported):
-  # Resume a paused run
+Examples:
+  # Resume a run
   globus flows run resume RUN_ID`,
 	Args: cobra.ExactArgs(1),
 	RunE: runFlowsRunResume,
 }
 
 func runFlowsRunResume(cmd *cobra.Command, args []string) error {
-	return fmt.Errorf("run resume is not yet available in SDK v3.65.0-1\n" +
-		"You can resume runs using:\n" +
-		"  1. The Globus web interface (https://app.globus.org)\n" +
-		"  2. The Python Globus CLI: globus flows run resume\n\n" +
-		"The Go SDK will add run resume support in a future release.")
+	runID := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if _, err := flowsClient.ResumeRun(ctx, runID); err != nil {
+		return fmt.Errorf("error resuming run: %w", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "Run %s resumed.\n", runID)
+	fmt.Fprintf(os.Stdout, "\nCheck status with: globus flows run show %s\n", runID)
+	return nil
 }

--- a/cmd/flows/validate.go
+++ b/cmd/flows/validate.go
@@ -1,43 +1,82 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
-
-// NOTE: This command is a placeholder because the Go SDK v3.65.0-1 does not
-// yet support flow definition validation.
-
 package flows
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+var validateSchemaFile string
 
 // ValidateCmd represents the flows validate command
 var ValidateCmd = &cobra.Command{
 	Use:   "validate DEFINITION_FILE",
-	Short: "Validate a flow definition (not yet supported)",
-	Long: `Validate a flow definition against the Flows schema.
+	Short: "Validate a flow definition",
+	Long: `Validate a flow definition against the Globus Flows schema, without
+creating a flow.
 
-NOTE: This command is not yet fully implemented because the Go SDK v3.65.0-1
-does not support flow definition validation.
+DEFINITION_FILE is a path to a JSON file containing the flow definition.
 
-You can validate your flow definition by:
-1. Using the Globus web interface (https://app.globus.org)
-2. Using the Python Globus CLI: globus flows validate
-3. Attempting to create the flow, which will validate on the server
-
-Examples (when supported):
+Examples:
   # Validate a flow definition
-  globus flows validate flow_definition.json`,
+  globus flows validate flow_definition.json
+
+  # Validate with an input schema
+  globus flows validate flow_definition.json --input-schema schema.json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runFlowsValidate,
 }
 
+func init() {
+	ValidateCmd.Flags().StringVar(&validateSchemaFile, "input-schema", "", "Path to an input schema JSON file")
+}
+
 func runFlowsValidate(cmd *cobra.Command, args []string) error {
-	return fmt.Errorf("flow definition validation is not yet available in SDK v3.65.0-1\n" +
-		"You can validate your flow definition by:\n" +
-		"  1. Using the Globus web interface (https://app.globus.org)\n" +
-		"  2. Using the Python Globus CLI: globus flows validate\n" +
-		"  3. Attempting to create the flow (server-side validation)\n\n" +
-		"The Go SDK will add validation support in a future release.")
+	definitionData, err := os.ReadFile(args[0])
+	if err != nil {
+		return fmt.Errorf("error reading definition file: %w", err)
+	}
+	var definition map[string]interface{}
+	if err := json.Unmarshal(definitionData, &definition); err != nil {
+		return fmt.Errorf("error parsing definition JSON: %w", err)
+	}
+
+	var inputSchema map[string]interface{}
+	if validateSchemaFile != "" {
+		schemaData, err := os.ReadFile(validateSchemaFile)
+		if err != nil {
+			return fmt.Errorf("error reading input schema file: %w", err)
+		}
+		if err := json.Unmarshal(schemaData, &inputSchema); err != nil {
+			return fmt.Errorf("error parsing input schema JSON: %w", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	flowsClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	result, err := flowsClient.ValidateFlow(ctx, definition, inputSchema)
+	if err != nil {
+		return fmt.Errorf("flow definition is invalid: %w", err)
+	}
+
+	format := viper.GetString("format")
+	if format != "text" {
+		return output.NewFormatter(format, os.Stdout).FormatOutput(result, nil)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Flow definition is valid.")
+	return nil
 }

--- a/cmd/group/list.go
+++ b/cmd/group/list.go
@@ -31,7 +31,7 @@ Examples:
   # List only groups where you are a member
   globus group list --my-groups
 
-  # List groups with specific statuses (SDK v3.65.0+ feature)
+  # List groups with specific statuses
   globus group list --include-status active --include-status pending
 
 Output Formats:

--- a/cmd/parity_test.go
+++ b/cmd/parity_test.go
@@ -75,6 +75,11 @@ func TestCommandParity(t *testing.T) {
 		"group member accept", "group policies show",
 		// Other grouped services.
 		"search query", "flows list", "timer list",
+		// Search index roles + task list.
+		"search index role list", "search index role create", "search index role delete",
+		"search task list",
+		// Flows run management + validation.
+		"flows run delete", "flows run resume", "flows validate",
 		// Raw API passthrough.
 		"api transfer", "api auth",
 		// Session.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,8 +35,11 @@ var (
 	mapHTTPStatus string
 )
 
-// Version is set during the build process
-var Version = "4.5.0-1"
+// Version is overridden at build time via -ldflags (see Makefile / .goreleaser:
+// it is set from `git describe --tags`). This default is only used for
+// non-release builds (e.g. `go run`/`go install` without ldflags), so it is a
+// clearly-non-release placeholder rather than a stale release number.
+var Version = "dev"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/search/index_role_create.go
+++ b/cmd/search/index_role_create.go
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
-
-// NOTE: This command is a placeholder because the Go SDK v3.65.0-1 does not
-// yet support role management for Search indices.
-
 package search
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/search"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -19,27 +21,50 @@ var (
 // IndexRoleCreateCmd represents the search index role create command
 var IndexRoleCreateCmd = &cobra.Command{
 	Use:   "create INDEX_ID PRINCIPAL",
-	Short: "Create a role on a Globus Search index (not yet supported)",
+	Short: "Create a role on a Globus Search index",
 	Long: `Create a new role granting permissions to a principal on an index.
 
-NOTE: This command is not yet fully implemented because the Go SDK v3.65.0-1
-does not support role management operations for Search indices.
+PRINCIPAL is a Globus Auth identity or group URN, e.g.
+urn:globus:auth:identity:<id> or urn:globus:groups:id:<group-id>.
 
-Examples (when supported):
-  # Grant admin role
-  globus search index role create INDEX_ID user@example.com --role admin
+Examples:
+  # Grant admin role to an identity
+  globus search index role create INDEX_ID urn:globus:auth:identity:USER_ID --role admin
 
-  # Grant reader role
-  globus search index role create INDEX_ID GROUP_ID --role reader`,
-	Args: cobra.MinimumNArgs(2),
+  # Grant writer role to a group
+  globus search index role create INDEX_ID urn:globus:groups:id:GROUP_ID --role writer`,
+	Args: cobra.ExactArgs(2),
 	RunE: runIndexRoleCreate,
 }
 
 func init() {
-	IndexRoleCreateCmd.Flags().StringVar(&roleCreateRole, "role", "reader", "Role name (reader, writer, admin, owner)")
+	IndexRoleCreateCmd.Flags().StringVar(&roleCreateRole, "role", "reader", "Role name (owner, admin, writer, reader)")
 }
 
 func runIndexRoleCreate(cmd *cobra.Command, args []string) error {
-	return fmt.Errorf("index role management is not yet available in SDK v3.65.0-1\n" +
-		"Please use the Globus web interface or Python Globus CLI.")
+	indexID := args[0]
+	principal := args[1]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	role, err := searchClient.AddRole(ctx, indexID, &search.RoleCreate{
+		RoleName:  roleCreateRole,
+		Principal: principal,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating role: %w", err)
+	}
+
+	format := viper.GetString("format")
+	if format != "text" {
+		return output.NewFormatter(format, os.Stdout).FormatOutput(role, nil)
+	}
+	fmt.Printf("Created role %s (%s) for %s on index %s\n", role.ID, role.RoleName, role.Principal, role.IndexID)
+	return nil
 }

--- a/cmd/search/index_role_delete.go
+++ b/cmd/search/index_role_delete.go
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
-
-// NOTE: This command is a placeholder because the Go SDK v3.65.0-1 does not
-// yet support role management for Search indices.
-
 package search
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -15,13 +13,10 @@ import (
 // IndexRoleDeleteCmd represents the search index role delete command
 var IndexRoleDeleteCmd = &cobra.Command{
 	Use:   "delete INDEX_ID ROLE_ID",
-	Short: "Delete a role from a Globus Search index (not yet supported)",
-	Long: `Delete a role from a Globus Search index.
+	Short: "Delete a role from a Globus Search index",
+	Long: `Delete a role assignment from a Globus Search index.
 
-NOTE: This command is not yet fully implemented because the Go SDK v3.65.0-1
-does not support role management operations for Search indices.
-
-Examples (when supported):
+Examples:
   # Delete a role
   globus search index role delete INDEX_ID ROLE_ID`,
 	Args: cobra.ExactArgs(2),
@@ -29,6 +24,21 @@ Examples (when supported):
 }
 
 func runIndexRoleDelete(cmd *cobra.Command, args []string) error {
-	return fmt.Errorf("index role management is not yet available in SDK v3.65.0-1\n" +
-		"Please use the Globus web interface or Python Globus CLI.")
+	indexID := args[0]
+	roleID := args[1]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := searchClient.RemoveRole(ctx, indexID, roleID); err != nil {
+		return fmt.Errorf("error deleting role: %w", err)
+	}
+
+	fmt.Printf("Deleted role %s from index %s\n", roleID, indexID)
+	return nil
 }

--- a/cmd/search/index_role_list.go
+++ b/cmd/search/index_role_list.go
@@ -1,47 +1,59 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
-
-// NOTE: This command is a placeholder because the Go SDK v3.65.0-1 does not
-// yet support role management for Search indices. The Python SDK has role
-// management capabilities that need to be ported to the Go SDK.
-//
-// Related functionality exists in the Globus Search API but is not exposed
-// in the current SDK version.
-
 package search
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // IndexRoleListCmd represents the search index role list command
 var IndexRoleListCmd = &cobra.Command{
 	Use:   "list INDEX_ID",
-	Short: "List roles on a Globus Search index (not yet supported)",
-	Long: `List all roles and permissions on a Globus Search index.
+	Short: "List roles on a Globus Search index",
+	Long: `List all role assignments on a Globus Search index.
 
-NOTE: This command is not yet fully implemented because the Go SDK v3.65.0-1
-does not support role management operations for Search indices.
-
-The Python Globus CLI and SDK support role management, but this functionality
-has not been ported to the Go SDK yet.
-
-To manage index roles, please use:
-- The Globus web interface at https://app.globus.org
-- The Python Globus CLI: pip install globus-cli
-
-Examples (when supported):
+Examples:
   # List roles on an index
-  globus search index role list INDEX_ID`,
+  globus search index role list INDEX_ID
+
+  # List with JSON output
+  globus search index role list INDEX_ID --format json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runIndexRoleList,
 }
 
 func runIndexRoleList(cmd *cobra.Command, args []string) error {
-	return fmt.Errorf("index role management is not yet available in SDK v3.65.0-1\n" +
-		"Please use the Globus web interface (https://app.globus.org) or\n" +
-		"the Python Globus CLI to manage Search index roles.\n\n" +
-		"The Go SDK will add role management support in a future release.")
+	indexID := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	roles, err := searchClient.ListRoles(ctx, indexID)
+	if err != nil {
+		return fmt.Errorf("error listing roles: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, os.Stdout)
+	if format != "text" {
+		return formatter.FormatOutput(roles, nil)
+	}
+
+	if len(roles.Roles) == 0 {
+		fmt.Println("No roles found.")
+		return nil
+	}
+	return formatter.FormatOutput(roles.Roles, []string{"ID", "RoleName", "Principal"})
 }

--- a/cmd/search/task_list.go
+++ b/cmd/search/task_list.go
@@ -1,41 +1,74 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
-
-// NOTE: This command is a placeholder because the Go SDK v3.65.0-1 does not
-// yet support listing tasks for a Search index.
-
 package search
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // TaskListCmd represents the search task list command
 var TaskListCmd = &cobra.Command{
 	Use:   "list INDEX_ID",
-	Short: "List recent tasks for an index (not yet supported)",
+	Short: "List recent tasks for a Globus Search index",
 	Long: `List recent indexing and deletion tasks for a Globus Search index.
 
-NOTE: This command is not yet fully implemented because the Go SDK v3.65.0-1
-does not support listing tasks for an index.
-
-You can still monitor individual tasks using: globus search task show TASK_ID
-
-Examples (when supported):
+Examples:
   # List recent tasks
   globus search task list INDEX_ID
 
-  # Limit results
-  globus search task list INDEX_ID --limit 20`,
+  # List with JSON output
+  globus search task list INDEX_ID --format json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runTaskList,
 }
 
 func runTaskList(cmd *cobra.Command, args []string) error {
-	return fmt.Errorf("task listing is not yet available in SDK v3.65.0-1\n" +
-		"You can still check individual task status using:\n" +
-		"  globus search task show TASK_ID\n\n" +
-		"The Go SDK will add task listing support in a future release.")
+	indexID := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	searchClient, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	tasks, err := searchClient.GetTaskList(ctx, indexID)
+	if err != nil {
+		return fmt.Errorf("error listing tasks: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, os.Stdout)
+	if format != "text" {
+		return formatter.FormatOutput(tasks, nil)
+	}
+
+	if len(tasks.Tasks) == 0 {
+		fmt.Println("No tasks found.")
+		return nil
+	}
+
+	type taskRow struct {
+		TaskID  string
+		State   string
+		Created string
+		Message string
+	}
+	rows := make([]taskRow, 0, len(tasks.Tasks))
+	for _, t := range tasks.Tasks {
+		created := ""
+		if !t.Created.IsZero() {
+			created = t.Created.Format(time.RFC3339)
+		}
+		rows = append(rows, taskRow{TaskID: t.TaskID, State: t.State, Created: created, Message: t.Message})
+	}
+	return formatter.FormatOutput(rows, []string{"TaskID", "State", "Created", "Message"})
 }

--- a/cmd/timer/create_transfer.go
+++ b/cmd/timer/create_transfer.go
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 
-// NOTE: This implementation uses direct HTTP calls to the Globus Timers v2 API
-// because the Go SDK v3.65.0-1 does not yet support transfer timers.
-// The SDK has FlowTimer helpers but no equivalent TransferTimer support.
-//
-// See SDK issue: https://github.com/scttfrdmn/globus-go-sdk/issues/16
-//
-// Once the SDK adds TransferTimer support (similar to Python SDK's TransferTimer
-// class), this implementation should be refactored to use the SDK's helper methods.
+// NOTE: This implementation uses direct HTTP calls to the Globus Timers v2 API.
+// The v4 SDK does provide CreateTransferTimer, but its schedule model takes an
+// interval in seconds, whereas this command accepts an ISO 8601 duration
+// (P1D/P1W/PT1H). Until the schedule helpers accept an ISO 8601 interval, the
+// raw request is retained; it sources its bearer token from the v4
+// per-resource-server store (see globusauth.TokenFor below).
 
 package timer
 

--- a/cmd/transfer/endpoint.go
+++ b/cmd/transfer/endpoint.go
@@ -239,5 +239,3 @@ func showEndpoint(cmd *cobra.Command, endpointID string) error {
 
 	return nil
 }
-
-// Note: formatDuration function removed as it is no longer needed in SDK v0.9.17

--- a/cmd/transfer/ls.go
+++ b/cmd/transfer/ls.go
@@ -113,7 +113,6 @@ func listDirectory(cmd *cobra.Command, endpointID, path string) error {
 		Name         string
 	}
 
-	// In SDK v0.9.17, the field is named Data instead of DATA
 	entries := make([]fileEntry, 0, len(listing.Data))
 
 	for _, item := range listing.Data {

--- a/cmd/transfer/task.go
+++ b/cmd/transfer/task.go
@@ -310,7 +310,6 @@ func cancelTask(cmd *cobra.Command, taskID string) error {
 		return fmt.Errorf("task %s is not active (status: %s), cannot cancel", taskID, task.Status)
 	}
 
-	// Cancel the task - CancelTask returns OperationResult and error in v0.9.17
 	result, err := transferClient.CancelTask(ctx, taskID)
 	if err != nil {
 		return fmt.Errorf("failed to cancel task: %w", err)
@@ -370,8 +369,11 @@ func waitForTask(cmd *cobra.Command, taskID string, timeout int) error {
 					color.Green("Task %s completed successfully", taskID)
 					fmt.Printf("Transferred %d files (%d bytes)\n", task.FilesTransferred, task.BytesTransferred)
 				} else if task.Status == "FAILED" {
-					// NiceStatus not available in v0.9.17
-					color.Red("Task %s failed", taskID)
+					if task.NiceStatus != "" {
+						color.Red("Task %s failed: %s", taskID, task.NiceStatus)
+					} else {
+						color.Red("Task %s failed", taskID)
+					}
 				} else {
 					fmt.Printf("Task %s status: %s\n", taskID, task.Status)
 				}

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -63,9 +63,9 @@ device-code flow and `identities lookup` performs a real `GetIdentities` call
 | Collections / GCS management | ✅ (`collection`, `gcs`, 32 cmds) | ✅ core set — `collection list/show/create/update/delete`, `gcs info`, `gcs storage-gateway list/show`, `gcs role list/show/create/delete` | Covered (Phase 7) |
 | GCP (Connect Personal) | ✅ (6) | ❌ none | Gap (no SDK support) |
 | Streams / tunnels | ✅ (8) | ✅ (`tunnel list/show/create/update/delete/events`, `stream-access-point list/show`) | Covered (Phase 5) |
-| Search (index/query/ingest/task/role/subject) | ✅ (14) | ✅ comparable | Covered |
+| Search (index/query/ingest/task/role/subject) | ✅ (14) | ✅ comparable — incl. `index role list/create/delete` and `task list` | Covered |
 | Groups (member/role/policy/invite/join/leave) | ✅ (19) | ✅ — create/delete/list/show/update, member add/invite/list/remove/accept/decline/approve/reject, join/leave, `policies show/set` | Covered (Phase 4) |
-| Flows (create/run/list/show/update/validate/logs) | ✅ (17) | ✅ comparable | Covered |
+| Flows (create/run/list/show/update/validate/logs) | ✅ (17) | ✅ comparable — incl. `validate`, `run delete`, `run resume` | Covered |
 | Timers | ✅ (7) | ✅ (create/list/show/pause/resume/delete) | Covered |
 | `api` raw passthrough | ✅ (7 services) | ✅ (`api auth/transfer/groups/search/flows/timer/compute`) | Covered (Phase 5) |
 | `session` (consent/show/update) | ✅ (3) | ✅ — `session show` (via `include=session_info`), `session update` (step-up re-auth), `session consent` (scoped consent) | Covered (Phase 8) |


### PR DESCRIPTION
## Turn 7 fake stubs into real commands + cleanup

Seven commands that returned "not yet supported in SDK v3.65.0-1" placeholders
are now real v4-SDK-backed commands (the SDK has had these since the v4
migration — the stubs were simply never updated):

- `search index role list` / `create` / `delete` — `ListRoles`/`AddRole`/`RemoveRole`
- `search task list` — `GetTaskList`
- `flows run delete` — `DeleteRun`
- `flows run resume` — `ResumeRun`
- `flows validate DEFINITION_FILE [--input-schema]` — `ValidateFlow`

### Stale-reference cleanup (CLI is fully on v4 now)
- Removed misleading `SDK v0.9.17` / `v3.65.0-1` comments in transfer
  `ls`/`task`/`endpoint` and the group-list help; `task.go` now surfaces
  `NiceStatus` on a FAILED task.
- `timer create_transfer`: corrected the note — v4 *has* `CreateTransferTimer`;
  the raw HTTP call is kept only because this command takes an ISO-8601
  interval, not because of missing SDK support.
- `root.go` `Version` default is now `"dev"` — it's overridden at build time
  from `git describe --tags`, so the old hardcoded `"4.5.0-1"` masqueraded as a
  release in `go run`/`go install` builds.

### Verification
`GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues; parity
test asserts the seven newly-real command paths; command trees render without
"not supported" text.