### PR TITLE
fix(ci): pin goreleaser-action to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,9 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: latest
+          # Must be v2: .goreleaser.yaml is `version: 2`. The action's "latest"
+          # default locks to the v1 line, which rejects a v2 config.
+          version: '~> v2'
           args: >-
             release --clean
             ${{ steps.dockercreds.outputs.available == 'true' && ' ' || '--skip=docker' }}


### PR DESCRIPTION
`.goreleaser.yaml` is `version: 2` but the action defaulted to the v1 line ("only configuration files on version: 1 are supported"). Pin `version: '~> v2'`. This was the real cause of the failed `v4.8.1-1` release; the Docker Hub login (fixed in #20) just failed first and hid it.