### PR TITLE
feat: project/client/credential management (globus-project-manager port)

### DIFF
--- a/cmd/parity_test.go
+++ b/cmd/parity_test.go
@@ -87,6 +87,10 @@ func TestCommandParity(t *testing.T) {
 		// GCSv5 collections + manager admin.
 		"collection list", "collection show", "collection create", "collection delete",
 		"gcs info", "gcs storage-gateway list", "gcs role list", "gcs role create",
+		// Project / client / credential management (globus-project-manager port).
+		"project list", "project create", "project admin add",
+		"project client list", "project client create",
+		"project credential list", "project credential rotate", "project credential process-deletions",
 		// Meta commands.
 		"list-commands", "version",
 	}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/scttfrdmn/globus-go-cli/cmd/project"
+)
+
+// getProjectCommand returns the `project` command group: management of Globus
+// Auth projects, their registered clients (service accounts), and client secret
+// credentials — the developer/console administrative surface. The `client` and
+// `credential` subgroups are attached here; the `admin` subgroup is attached by
+// ProjectCmd itself.
+func getProjectCommand() *cobra.Command {
+	projectCmd := project.ProjectCmd()
+	projectCmd.AddCommand(project.ProjectClientCmd())
+	projectCmd.AddCommand(project.CredentialCmd())
+	return projectCmd
+}

--- a/cmd/project/admin.go
+++ b/cmd/project/admin.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package project
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
+)
+
+// adminCmd returns the admin subgroup for managing a project's administrators.
+func adminCmd() *cobra.Command {
+	admin := &cobra.Command{
+		Use:   "admin",
+		Short: "Commands for managing project administrators",
+		Long:  `List, add, and remove administrators on a Globus Auth project.`,
+	}
+
+	admin.AddCommand(
+		adminListCmd(),
+		adminAddCmd(),
+		adminRemoveCmd(),
+	)
+
+	return admin
+}
+
+// adminListCmd returns the admin list command.
+func adminListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list PROJECT_ID",
+		Short: "List a project's administrators",
+		Long:  `List the administrator identities and admin groups on a Globus Auth project.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listAdmins(cmd, args[0])
+		},
+	}
+}
+
+// adminAddCmd returns the admin add command.
+func adminAddCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add PROJECT_ID IDENTITY_OR_USERNAME",
+		Short: "Add an administrator to a project",
+		Long: `Add an administrator to a Globus Auth project.
+
+The second argument may be an identity ID (UUID) or a username; a username is
+resolved to its identity ID via Globus Auth (provisioning if necessary).`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return addAdmin(cmd, args[0], args[1])
+		},
+	}
+}
+
+// adminRemoveCmd returns the admin remove command.
+func adminRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove PROJECT_ID IDENTITY_ID",
+		Short: "Remove an administrator from a project",
+		Long:  `Remove an administrator identity from a Globus Auth project.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return removeAdmin(cmd, args[0], args[1])
+		},
+	}
+}
+
+// listAdmins displays a project's administrator identities and groups.
+func listAdmins(cmd *cobra.Command, projectID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	project, err := client.GetProject(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to get project: %w", err)
+	}
+
+	// Collect admin identity IDs from both the flat list and the expanded
+	// admins object (deduped).
+	identities := dedupeStrings(project.AdminIDs)
+	groups := append([]string(nil), project.AdminGroupIDs...)
+	if project.Admins != nil {
+		identities = dedupeStrings(append(identities, project.Admins.Identities...))
+		groups = dedupeStrings(append(groups, project.Admins.Groups...))
+	}
+	groups = dedupeStrings(groups)
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(project, nil)
+	}
+
+	type adminRow struct {
+		IdentityID string
+	}
+	rows := make([]adminRow, 0, len(identities))
+	for _, id := range identities {
+		rows = append(rows, adminRow{IdentityID: id})
+	}
+	if err := formatter.FormatOutput(rows, []string{"IdentityID"}); err != nil {
+		return err
+	}
+
+	if len(groups) > 0 {
+		fmt.Println("\nAdmin Groups:")
+		for _, g := range groups {
+			fmt.Printf("  %s\n", g)
+		}
+	}
+
+	return nil
+}
+
+// addAdmin resolves the given identity-or-username to an identity ID and adds
+// it to the project's admin list (preserving other fields).
+func addAdmin(cmd *cobra.Command, projectID, identityOrUsername string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	identityID, err := resolveIdentityID(ctx, client, identityOrUsername)
+	if err != nil {
+		return err
+	}
+
+	project, err := client.GetProject(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to get project: %w", err)
+	}
+
+	merged := dedupeStrings(append(project.AdminIDs, identityID))
+
+	update := &auth.ProjectUpdate{
+		DisplayName:  project.DisplayName,
+		ContactEmail: project.ContactEmail,
+		AdminIDs:     merged,
+	}
+	if _, err := client.UpdateProject(ctx, projectID, update); err != nil {
+		return fmt.Errorf("failed to update project admins: %w", err)
+	}
+
+	fmt.Printf("Added admin %s to project %s\n", identityID, projectID)
+	return nil
+}
+
+// removeAdmin removes an identity ID from the project's admin list (preserving
+// other fields).
+func removeAdmin(cmd *cobra.Command, projectID, identityID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	project, err := client.GetProject(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to get project: %w", err)
+	}
+
+	reduced := make([]string, 0, len(project.AdminIDs))
+	for _, id := range project.AdminIDs {
+		if id != identityID {
+			reduced = append(reduced, id)
+		}
+	}
+
+	update := &auth.ProjectUpdate{
+		DisplayName:  project.DisplayName,
+		ContactEmail: project.ContactEmail,
+		AdminIDs:     reduced,
+	}
+	if _, err := client.UpdateProject(ctx, projectID, update); err != nil {
+		return fmt.Errorf("failed to update project admins: %w", err)
+	}
+
+	fmt.Printf("Removed admin %s from project %s\n", identityID, projectID)
+	return nil
+}
+
+// resolveIdentityID returns an identity ID for the given argument. If the
+// argument looks like an ID (no "@"), it is used as-is; otherwise it is treated
+// as a username and looked up (provisioning if necessary).
+func resolveIdentityID(ctx context.Context, client *auth.Client, arg string) (string, error) {
+	if !strings.Contains(arg, "@") {
+		return arg, nil
+	}
+
+	identities, err := client.GetIdentities(ctx, &auth.GetIdentitiesOptions{
+		Usernames: []string{arg},
+		Provision: true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve identity %q: %w", arg, err)
+	}
+	if len(identities) == 0 {
+		return "", fmt.Errorf("no identity found for username %q", arg)
+	}
+	return identities[0].ID, nil
+}
+
+// dedupeStrings returns the input with duplicate and empty entries removed,
+// preserving order.
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/cmd/project/client.go
+++ b/cmd/project/client.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+
+// Package project implements the `globus project` command tree: management of
+// Globus Auth projects, their registered clients (service accounts / app
+// registrations), and client secret credentials — the "developer console"
+// administrative surface. It ports the standalone globus-project-manager tool
+// onto the v4 SDK.
+//
+// These operations require the auth.globus.org `manage_projects` scope, which
+// the standard `globus login` scope set does not include. getClient obtains a
+// manage_projects authorizer via a dedicated consent (escalated on first use),
+// stored under its own token-storage namespace so it never collides with the
+// login token (both live on the auth.globus.org resource server).
+package project
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
+)
+
+const (
+	// manageProjectsScope is the Globus Auth scope required for project /
+	// client / credential management.
+	manageProjectsScope = "urn:globus:auth:scope:auth.globus.org:manage_projects"
+	// authResourceServer is the resource server manage_projects tokens key on.
+	authResourceServer = "auth.globus.org"
+	// manageProjectsNamespace isolates the manage_projects consent token from
+	// the login token (both are on auth.globus.org).
+	manageProjectsNamespace = "globus-cli-manage-projects"
+)
+
+// getClient builds a v4 Auth client authorized with the manage_projects scope
+// for the current profile, escalating consent (a paste-code login) on first
+// use. Used by every project/client/credential command.
+func getClient(ctx context.Context) (*auth.Client, error) {
+	profile := viper.GetString("profile")
+
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	cfg, err := globusauth.ScopedClientConfigWithNamespace(
+		ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret,
+		authResourceServer, manageProjectsScope, manageProjectsNamespace, true,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not obtain manage_projects consent: %w", err)
+	}
+
+	client, err := auth.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth client: %w", err)
+	}
+	return client, nil
+}

--- a/cmd/project/client_cmd.go
+++ b/cmd/project/client_cmd.go
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package project
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
+)
+
+// Flag-backed options for the client subcommands. Prefixed to avoid collisions
+// with sibling files in the project package.
+var (
+	clientCreateProject     string
+	clientCreateName        string
+	clientCreatePublic      bool
+	clientCreateVisibility  string
+	clientCreateRedirectURI []string
+	clientCreateType        string
+
+	clientUpdateName       string
+	clientUpdateVisibility string
+
+	clientRedirectURIs []string
+
+	clientPrivacyPolicy      string
+	clientTermsAndConditions string
+)
+
+// ProjectClientCmd returns the `client` command tree for managing the Globus
+// Auth clients (app / service-account registrations) within a project.
+func ProjectClientCmd() *cobra.Command {
+	clientCmd := &cobra.Command{
+		Use:   "client",
+		Short: "Commands for managing Globus Auth clients",
+		Long: `Manage the Globus Auth clients (application and service-account
+registrations) belonging to your projects.
+
+These operations require the auth.globus.org manage_projects scope.`,
+	}
+
+	clientCmd.AddCommand(
+		pcListCmd(),
+		pcShowCmd(),
+		pcCreateCmd(),
+		pcUpdateCmd(),
+		pcDeleteCmd(),
+		pcUpdateRedirectURIsCmd(),
+		pcUpdateMetadataCmd(),
+	)
+
+	return clientCmd
+}
+
+// pcListCmd returns the `client list` command.
+func pcListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list PROJECT_ID",
+		Short: "List clients in a project",
+		Long: `List the Globus Auth clients belonging to the given project.
+
+The Auth API returns all clients across your projects; this command filters
+them to the requested project ID.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pcList(cmd, args[0])
+		},
+	}
+}
+
+// pcShowCmd returns the `client show` command.
+func pcShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show CLIENT_ID",
+		Short: "Show client details",
+		Long:  `Show detailed information about a single Globus Auth client.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pcShow(cmd, args[0])
+		},
+	}
+}
+
+// pcCreateCmd returns the `client create` command.
+func pcCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a client",
+		Long:  `Create a new Globus Auth client in a project.`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pcCreate(cmd)
+		},
+	}
+
+	cmd.Flags().StringVar(&clientCreateProject, "project", "", "Project ID to create the client in (required)")
+	cmd.Flags().StringVar(&clientCreateName, "name", "", "Display name for the client (required)")
+	cmd.Flags().BoolVar(&clientCreatePublic, "public", false, "Register the client as a public (native app) client")
+	cmd.Flags().StringVar(&clientCreateVisibility, "visibility", "", "Client visibility (public or private)")
+	cmd.Flags().StringSliceVar(&clientCreateRedirectURI, "redirect-uri", nil, "Redirect URI (repeatable)")
+	cmd.Flags().StringVar(&clientCreateType, "client-type", "", "Client type")
+	_ = cmd.MarkFlagRequired("project")
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+// pcUpdateCmd returns the `client update` command.
+func pcUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update CLIENT_ID",
+		Short: "Update a client",
+		Long:  `Update the mutable fields (name, visibility) of a Globus Auth client.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pcUpdate(cmd, args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&clientUpdateName, "name", "", "New display name for the client")
+	cmd.Flags().StringVar(&clientUpdateVisibility, "visibility", "", "New client visibility (public or private)")
+
+	return cmd
+}
+
+// pcDeleteCmd returns the `client delete` command.
+func pcDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete CLIENT_ID",
+		Short: "Delete a client",
+		Long:  `Delete a Globus Auth client.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pcDelete(cmd, args[0])
+		},
+	}
+}
+
+// pcUpdateRedirectURIsCmd returns the `client update-redirect-uris` command.
+func pcUpdateRedirectURIsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-redirect-uris CLIENT_ID",
+		Short: "Update a client's redirect URIs",
+		Long:  `Replace the set of redirect URIs registered on a Globus Auth client.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pcUpdateRedirectURIs(cmd, args[0])
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&clientRedirectURIs, "redirect-uri", nil, "Redirect URI (repeatable, required)")
+	_ = cmd.MarkFlagRequired("redirect-uri")
+
+	return cmd
+}
+
+// pcUpdateMetadataCmd returns the `client update-metadata` command.
+func pcUpdateMetadataCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-metadata CLIENT_ID",
+		Short: "Update a client's metadata links",
+		Long:  `Update the privacy policy and terms-and-conditions links on a Globus Auth client.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pcUpdateMetadata(cmd, args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&clientPrivacyPolicy, "privacy-policy", "", "URL of the client's privacy policy")
+	cmd.Flags().StringVar(&clientTermsAndConditions, "terms-and-conditions", "", "URL of the client's terms and conditions")
+
+	return cmd
+}
+
+// pcList lists the clients belonging to a project.
+func pcList(cmd *cobra.Command, projectID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	all, err := client.GetClients(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list clients: %w", err)
+	}
+
+	// GetClients returns every client across the caller's projects; filter to
+	// the requested project (there is no per-project list method).
+	filtered := make([]auth.AuthClientInfo, 0, len(all))
+	for _, c := range all {
+		if c.Project == projectID {
+			filtered = append(filtered, c)
+		}
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(filtered, nil)
+	}
+
+	type clientRow struct {
+		ID           string
+		Name         string
+		ClientType   string
+		PublicClient bool
+	}
+	rows := make([]clientRow, 0, len(filtered))
+	for _, c := range filtered {
+		rows = append(rows, clientRow{
+			ID: c.ID, Name: c.Name, ClientType: c.ClientType, PublicClient: c.PublicClient,
+		})
+	}
+	return formatter.FormatOutput(rows, []string{"ID", "Name", "ClientType", "PublicClient"})
+}
+
+// pcShow shows details for a single client.
+func pcShow(cmd *cobra.Command, clientID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	info, err := client.GetClient(ctx, &auth.GetClientOptions{ClientID: clientID})
+	if err != nil {
+		return fmt.Errorf("failed to get client: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(info, nil)
+	}
+
+	fmt.Println("Client Details:")
+	fmt.Printf("  ID:            %s\n", info.ID)
+	fmt.Printf("  Name:          %s\n", info.Name)
+	fmt.Printf("  Project:       %s\n", info.Project)
+	fmt.Printf("  Client Type:   %s\n", info.ClientType)
+	fmt.Printf("  Visibility:    %s\n", info.Visibility)
+	fmt.Printf("  Redirect URIs: %v\n", info.RedirectURIs)
+	fmt.Printf("  Public Client: %t\n", info.PublicClient)
+
+	return nil
+}
+
+// pcCreate creates a new client.
+func pcCreate(cmd *cobra.Command) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	req := &auth.ClientCreate{
+		Name:         clientCreateName,
+		Project:      clientCreateProject,
+		Visibility:   clientCreateVisibility,
+		RedirectURIs: clientCreateRedirectURI,
+		ClientType:   clientCreateType,
+	}
+	// Only send public_client when the flag was explicitly set.
+	if cmd.Flags().Changed("public") {
+		public := clientCreatePublic
+		req.PublicClient = &public
+	}
+
+	created, err := client.CreateClient(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	fmt.Printf("Created client %s (%s)\n", created.ID, created.Name)
+	return nil
+}
+
+// pcUpdate updates the mutable fields of a client.
+func pcUpdate(cmd *cobra.Command, clientID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	update := &auth.ClientUpdate{}
+	if cmd.Flags().Changed("name") {
+		update.Name = clientUpdateName
+	}
+	if cmd.Flags().Changed("visibility") {
+		update.Visibility = clientUpdateVisibility
+	}
+
+	if _, err := client.UpdateClient(ctx, clientID, update); err != nil {
+		return fmt.Errorf("failed to update client: %w", err)
+	}
+
+	fmt.Printf("Updated client %s\n", clientID)
+	return nil
+}
+
+// pcDelete deletes a client.
+func pcDelete(cmd *cobra.Command, clientID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := client.DeleteClient(ctx, clientID); err != nil {
+		return fmt.Errorf("failed to delete client: %w", err)
+	}
+
+	fmt.Printf("Deleted client %s\n", clientID)
+	return nil
+}
+
+// pcUpdateRedirectURIs replaces a client's redirect URIs.
+func pcUpdateRedirectURIs(cmd *cobra.Command, clientID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	update := &auth.ClientUpdate{RedirectURIs: clientRedirectURIs}
+	if _, err := client.UpdateClient(ctx, clientID, update); err != nil {
+		return fmt.Errorf("failed to update redirect URIs: %w", err)
+	}
+
+	fmt.Printf("Updated redirect URIs for client %s\n", clientID)
+	return nil
+}
+
+// pcUpdateMetadata updates a client's terms/privacy metadata links.
+func pcUpdateMetadata(cmd *cobra.Command, clientID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	links := &auth.ClientLinksInput{}
+	if cmd.Flags().Changed("privacy-policy") {
+		links.PrivacyPolicy = clientPrivacyPolicy
+	}
+	if cmd.Flags().Changed("terms-and-conditions") {
+		links.TermsAndConditions = clientTermsAndConditions
+	}
+
+	update := &auth.ClientUpdate{Links: links}
+	if _, err := client.UpdateClient(ctx, clientID, update); err != nil {
+		return fmt.Errorf("failed to update client metadata: %w", err)
+	}
+
+	fmt.Printf("Updated metadata for client %s\n", clientID)
+	return nil
+}

--- a/cmd/project/credential.go
+++ b/cmd/project/credential.go
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+
+package project
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+)
+
+// Flag variables for the credential subcommands. Prefixed with `cred` to avoid
+// collisions with other command groups in the project package.
+var (
+	credCreateName string
+	credRotateName string
+	credRotateDays int
+)
+
+// CredentialCmd returns the `credential` command tree for managing a client's
+// secret credentials, including CLI-side credential rotation and scheduled
+// deletion (rotation metadata is persisted in the per-profile state store,
+// since the Globus Auth API has no rotation primitive).
+func CredentialCmd() *cobra.Command {
+	credentialCmd := &cobra.Command{
+		Use:   "credential",
+		Short: "Commands for managing client credentials",
+		Long: `List, create, delete, and rotate the secret credentials of a Globus Auth
+client, plus process scheduled credential deletions.
+
+Rotation and scheduled deletion metadata is tracked in a per-profile state
+file, since the Globus Auth API has no native rotation primitive.`,
+	}
+
+	credentialCmd.AddCommand(
+		credListCmd(),
+		credCreateCmd(),
+		credDeleteCmd(),
+		credRotateCmd(),
+		credListAgeCmd(),
+		credProcessDeletionsCmd(),
+	)
+
+	return credentialCmd
+}
+
+// credListCmd returns the `credential list` command.
+func credListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list CLIENT_ID",
+		Short: "List a client's credentials",
+		Long:  `List the secret credentials of the given Globus Auth client.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return credList(cmd, args[0])
+		},
+	}
+}
+
+// credCreateCmd returns the `credential create` command.
+func credCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create CLIENT_ID",
+		Short: "Create a new client credential",
+		Long: `Create a new secret credential for the given Globus Auth client.
+
+The credential's secret is printed only once, at creation time. Store it
+securely; it cannot be retrieved again.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return credCreate(cmd, args[0])
+		},
+	}
+	cmd.Flags().StringVar(&credCreateName, "name", "", "Name for the new credential (required)")
+	_ = cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+// credDeleteCmd returns the `credential delete` command.
+func credDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete CLIENT_ID CREDENTIAL_ID",
+		Short: "Delete a client credential",
+		Long:  `Delete the given credential from the given Globus Auth client.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return credDelete(cmd, args[0], args[1])
+		},
+	}
+}
+
+// credRotateCmd returns the `credential rotate` command.
+func credRotateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rotate CLIENT_ID CREDENTIAL_ID",
+		Short: "Rotate a client credential",
+		Long: `Rotate a client credential: create a replacement credential and schedule
+the old one for deletion after a transition period.
+
+The new credential's secret is printed only once, here. The old credential is
+not deleted immediately; run "credential process-deletions" after the
+transition period to delete credentials whose scheduled deletion has passed.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return credRotate(cmd, args[0], args[1])
+		},
+	}
+	cmd.Flags().StringVar(&credRotateName, "name", "", "Name for the new credential (default \"Rotated from <old>\")")
+	cmd.Flags().IntVar(&credRotateDays, "transition-days", 7, "Days until the old credential is scheduled for deletion (0 to skip scheduling)")
+	return cmd
+}
+
+// credListAgeCmd returns the `credential list-age` command.
+func credListAgeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-age CLIENT_ID",
+		Short: "List a client's credentials with their age",
+		Long: `List the given client's credentials along with each credential's age in
+days and any scheduled deletion time recorded in the local state store.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return credListAge(cmd, args[0])
+		},
+	}
+}
+
+// credProcessDeletionsCmd returns the `credential process-deletions` command.
+func credProcessDeletionsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "process-deletions",
+		Short: "Delete credentials whose scheduled deletion has passed",
+		Long: `Delete all credentials (across clients) whose scheduled deletion time,
+recorded during rotation, is now in the past. A failure to delete one
+credential does not stop processing of the others.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return credProcessDeletions(cmd)
+		},
+	}
+}
+
+// credList lists a client's credentials.
+func credList(cmd *cobra.Command, clientID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	creds, err := client.GetClientCredentials(ctx, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to list credentials: %w", err)
+	}
+
+	formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(creds, nil)
+	}
+
+	type credRow struct {
+		ID      string
+		Name    string
+		Created string
+	}
+	rows := make([]credRow, 0, len(creds))
+	for _, c := range creds {
+		rows = append(rows, credRow{
+			ID:      c.ID,
+			Name:    c.Name,
+			Created: c.Created.Format(time.RFC3339),
+		})
+	}
+	return formatter.FormatOutput(rows, []string{"ID", "Name", "Created"})
+}
+
+// credCreate creates a new credential and records it in the state store.
+func credCreate(cmd *cobra.Command, clientID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	cred, err := client.CreateClientCredential(ctx, clientID, credCreateName)
+	if err != nil {
+		return fmt.Errorf("failed to create credential: %w", err)
+	}
+
+	st, err := loadState()
+	if err != nil {
+		return err
+	}
+	st.Credentials[cred.ID] = credentialRecord{ClientID: clientID, Name: credCreateName}
+	if err := saveState(st); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Created credential %s (%s)\n", cred.ID, cred.Name)
+	if cred.Secret != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "Secret: %s\n", *cred.Secret)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "The secret is shown only once; store it securely.")
+	return nil
+}
+
+// credDelete deletes a credential and removes it from the state store.
+func credDelete(cmd *cobra.Command, clientID, credentialID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := client.DeleteClientCredential(ctx, clientID, credentialID); err != nil {
+		return fmt.Errorf("failed to delete credential: %w", err)
+	}
+
+	st, err := loadState()
+	if err != nil {
+		return err
+	}
+	delete(st.Credentials, credentialID)
+	if err := saveState(st); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Deleted credential %s\n", credentialID)
+	return nil
+}
+
+// credRotate rotates a credential: it creates a replacement and schedules the
+// old credential for deletion, tracking the transition in the state store.
+func credRotate(cmd *cobra.Command, clientID, credentialID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Verify the old credential exists.
+	creds, err := client.GetClientCredentials(ctx, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to list credentials: %w", err)
+	}
+	found := false
+	for _, c := range creds {
+		if c.ID == credentialID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("credential %s not found on client %s", credentialID, clientID)
+	}
+
+	name := credRotateName
+	if name == "" {
+		name = fmt.Sprintf("Rotated from %s", credentialID)
+	}
+
+	newCred, err := client.CreateClientCredential(ctx, clientID, name)
+	if err != nil {
+		return fmt.Errorf("failed to create replacement credential: %w", err)
+	}
+
+	st, err := loadState()
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	var scheduled string
+	if credRotateDays > 0 {
+		scheduled = now.Add(time.Duration(credRotateDays) * 24 * time.Hour).Format(time.RFC3339)
+	}
+
+	// Update (or create) the old credential's record with rotation metadata.
+	oldRec := st.Credentials[credentialID]
+	oldRec.ClientID = clientID
+	oldRec.RotatedTo = newCred.ID
+	oldRec.ScheduledDeletion = scheduled
+	st.Credentials[credentialID] = oldRec
+
+	// Ensure a record exists for the new credential.
+	newRec := st.Credentials[newCred.ID]
+	newRec.ClientID = clientID
+	newRec.Name = name
+	newRec.RotatedFrom = credentialID
+	st.Credentials[newCred.ID] = newRec
+
+	if err := saveState(st); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Rotated credential %s -> %s (%s)\n", credentialID, newCred.ID, name)
+	if newCred.Secret != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "Secret: %s\n", *newCred.Secret)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "The secret is shown only once; store it securely.")
+	if scheduled != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Old credential %s scheduled for deletion at %s\n", credentialID, scheduled)
+		fmt.Fprintln(cmd.OutOrStdout(), "Run \"globus project credential process-deletions\" after the transition period.")
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "Old credential %s not scheduled for deletion (transition-days=0).\n", credentialID)
+	}
+	return nil
+}
+
+// credListAge lists a client's credentials with their age in days and any
+// scheduled deletion recorded in the state store.
+func credListAge(cmd *cobra.Command, clientID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	creds, err := client.GetClientCredentials(ctx, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to list credentials: %w", err)
+	}
+
+	st, err := loadState()
+	if err != nil {
+		return err
+	}
+
+	type ageRow struct {
+		ID                string    `json:"id"`
+		Name              string    `json:"name"`
+		Created           time.Time `json:"created"`
+		AgeDays           int       `json:"age_days"`
+		ScheduledDeletion string    `json:"scheduled_deletion,omitempty"`
+	}
+	rows := make([]ageRow, 0, len(creds))
+	now := time.Now()
+	for _, c := range creds {
+		ageDays := int(now.Sub(c.Created).Hours() / 24)
+		scheduled := ""
+		if rec, ok := st.Credentials[c.ID]; ok {
+			scheduled = rec.ScheduledDeletion
+		}
+		rows = append(rows, ageRow{
+			ID:                c.ID,
+			Name:              c.Name,
+			Created:           c.Created,
+			AgeDays:           ageDays,
+			ScheduledDeletion: scheduled,
+		})
+	}
+
+	formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(rows, nil)
+	}
+
+	type ageTextRow struct {
+		ID                string
+		Name              string
+		AgeDays           int
+		ScheduledDeletion string
+	}
+	textRows := make([]ageTextRow, 0, len(rows))
+	for _, r := range rows {
+		textRows = append(textRows, ageTextRow{
+			ID:                r.ID,
+			Name:              r.Name,
+			AgeDays:           r.AgeDays,
+			ScheduledDeletion: r.ScheduledDeletion,
+		})
+	}
+	return formatter.FormatOutput(textRows, []string{"ID", "Name", "AgeDays", "ScheduledDeletion"})
+}
+
+// credProcessDeletions deletes every credential whose scheduled deletion time
+// has passed. One failure does not abort processing of the rest.
+func credProcessDeletions(cmd *cobra.Command) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	st, err := loadState()
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	var deleted, failed int
+	for id, rec := range st.Credentials {
+		if rec.ScheduledDeletion == "" {
+			continue
+		}
+		when, err := time.Parse(time.RFC3339, rec.ScheduledDeletion)
+		if err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "Skipping %s: invalid scheduled deletion %q: %v\n", id, rec.ScheduledDeletion, err)
+			continue
+		}
+		if when.After(now) {
+			continue
+		}
+		if err := client.DeleteClientCredential(ctx, rec.ClientID, id); err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "Warning: failed to delete credential %s (client %s): %v\n", id, rec.ClientID, err)
+			failed++
+			continue
+		}
+		delete(st.Credentials, id)
+		deleted++
+		fmt.Fprintf(cmd.OutOrStdout(), "Deleted credential %s (client %s)\n", id, rec.ClientID)
+	}
+
+	if err := saveState(st); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Processed scheduled deletions: %d deleted, %d failed\n", deleted, failed)
+	return nil
+}

--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package project
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
+)
+
+// Flags for project create/update.
+var (
+	projectDisplayName  string
+	projectContactEmail string
+	projectAdmins       []string
+	projectAdminGroups  []string
+)
+
+// ProjectCmd returns the project command tree for managing Globus Auth
+// projects. Every subcommand obtains a manage_projects-scoped auth client via
+// getClient (escalating consent on first use).
+func ProjectCmd() *cobra.Command {
+	projectCmd := &cobra.Command{
+		Use:   "project",
+		Short: "Commands for managing Globus Auth projects",
+		Long: `Manage Globus Auth projects — the developer-console administrative surface
+for grouping registered clients (service accounts / app registrations).
+
+These operations require the auth.globus.org manage_projects scope, which is
+requested via a dedicated consent on first use.`,
+	}
+
+	projectCmd.AddCommand(
+		projectListCmd(),
+		projectShowCmd(),
+		projectCreateCmd(),
+		projectUpdateCmd(),
+		projectDeleteCmd(),
+		adminCmd(),
+	)
+
+	return projectCmd
+}
+
+// projectListCmd returns the project list command.
+func projectListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List your Globus Auth projects",
+		Long:  `List the Globus Auth projects on which the current user is an administrator.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listProjects(cmd)
+		},
+	}
+}
+
+// projectShowCmd returns the project show command.
+func projectShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show PROJECT_ID",
+		Short: "Show project details",
+		Long:  `Show detailed information about a specific Globus Auth project.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showProject(cmd, args[0])
+		},
+	}
+}
+
+// projectCreateCmd returns the project create command.
+func projectCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new project",
+		Long: `Create a new Globus Auth project.
+
+At least one administrator must be provided via --admin or --admin-group.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return createProject(cmd)
+		},
+	}
+
+	cmd.Flags().StringVar(&projectDisplayName, "display-name", "", "Display name for the project (required)")
+	cmd.Flags().StringVar(&projectContactEmail, "contact-email", "", "Contact email for the project")
+	cmd.Flags().StringSliceVar(&projectAdmins, "admin", nil, "Identity ID of an admin (repeatable)")
+	cmd.Flags().StringSliceVar(&projectAdminGroups, "admin-group", nil, "Group ID of an admin group (repeatable)")
+	_ = cmd.MarkFlagRequired("display-name")
+
+	return cmd
+}
+
+// projectUpdateCmd returns the project update command.
+func projectUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update PROJECT_ID",
+		Short: "Update a project",
+		Long: `Update a Globus Auth project.
+
+Only the flags you provide are changed; unset fields are left as-is.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return updateProject(cmd, args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&projectDisplayName, "display-name", "", "New display name for the project")
+	cmd.Flags().StringVar(&projectContactEmail, "contact-email", "", "New contact email for the project")
+
+	return cmd
+}
+
+// projectDeleteCmd returns the project delete command.
+func projectDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete PROJECT_ID",
+		Short: "Delete a project",
+		Long:  `Delete a Globus Auth project.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deleteProject(cmd, args[0])
+		},
+	}
+}
+
+// listProjects lists the current user's projects.
+func listProjects(cmd *cobra.Command) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	projects, err := client.GetProjects(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list projects: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(projects, nil)
+	}
+
+	type projectRow struct {
+		ID           string
+		DisplayName  string
+		ContactEmail string
+	}
+	rows := make([]projectRow, 0, len(projects))
+	for _, p := range projects {
+		rows = append(rows, projectRow{
+			ID: p.ID, DisplayName: p.DisplayName, ContactEmail: p.ContactEmail,
+		})
+	}
+	return formatter.FormatOutput(rows, []string{"ID", "DisplayName", "ContactEmail"})
+}
+
+// showProject shows details for a single project.
+func showProject(cmd *cobra.Command, projectID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	project, err := client.GetProject(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to get project: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(project, nil)
+	}
+
+	fmt.Println("Project Details:")
+	fmt.Printf("  ID:            %s\n", project.ID)
+	fmt.Printf("  Display Name:  %s\n", project.DisplayName)
+	fmt.Printf("  Contact Email: %s\n", project.ContactEmail)
+	fmt.Printf("  Admin IDs:     %v\n", project.AdminIDs)
+	fmt.Printf("  Created At:    %s\n", project.CreatedAt.Format(time.RFC3339))
+
+	return nil
+}
+
+// createProject creates a new project.
+func createProject(cmd *cobra.Command) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	create := &auth.ProjectCreate{
+		DisplayName:   projectDisplayName,
+		ContactEmail:  projectContactEmail,
+		AdminIDs:      projectAdmins,
+		AdminGroupIDs: projectAdminGroups,
+	}
+
+	project, err := client.CreateProject(ctx, create)
+	if err != nil {
+		return fmt.Errorf("failed to create project: %w", err)
+	}
+
+	fmt.Printf("Created project %s (%s)\n", project.ID, project.DisplayName)
+	return nil
+}
+
+// updateProject updates a project, sending only the flags that were set.
+func updateProject(cmd *cobra.Command, projectID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	update := &auth.ProjectUpdate{}
+	if cmd.Flags().Changed("display-name") {
+		update.DisplayName = projectDisplayName
+	}
+	if cmd.Flags().Changed("contact-email") {
+		update.ContactEmail = projectContactEmail
+	}
+
+	if _, err := client.UpdateProject(ctx, projectID, update); err != nil {
+		return fmt.Errorf("failed to update project: %w", err)
+	}
+
+	fmt.Printf("Updated project %s\n", projectID)
+	return nil
+}
+
+// deleteProject deletes a project.
+func deleteProject(cmd *cobra.Command, projectID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := client.DeleteProject(ctx, projectID); err != nil {
+		return fmt.Errorf("failed to delete project: %w", err)
+	}
+
+	fmt.Printf("Deleted project %s\n", projectID)
+	return nil
+}

--- a/cmd/project/state.go
+++ b/cmd/project/state.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+)
+
+// credentialRecord tracks CLI-side rotation metadata for a single client
+// credential. The Globus Auth API has no rotation/scheduling primitive, so
+// `rotate`/`process-deletions` maintain this state locally (mirroring the
+// globus-project-manager tool's credential_metadata).
+type credentialRecord struct {
+	ClientID          string `json:"client_id"`
+	Name              string `json:"name,omitempty"`
+	RotatedTo         string `json:"rotated_to,omitempty"`
+	RotatedFrom       string `json:"rotated_from,omitempty"`
+	ScheduledDeletion string `json:"scheduled_deletion,omitempty"` // RFC3339
+}
+
+// credentialState is the on-disk per-profile rotation state, keyed by
+// credential ID.
+type credentialState struct {
+	Credentials map[string]credentialRecord `json:"credentials"`
+}
+
+// statePath returns the per-profile credential-state file path
+// (~/.globus-cli/credential-state-<profile>.json), alongside the token store.
+func statePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	profile := viper.GetString("profile")
+	if profile == "" {
+		profile = "default"
+	}
+	dir := filepath.Join(home, ".globus-cli")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("cannot create state directory: %w", err)
+	}
+	return filepath.Join(dir, "credential-state-"+profile+".json"), nil
+}
+
+// loadState reads the per-profile credential state, returning an empty (but
+// non-nil) state if the file does not exist.
+func loadState() (*credentialState, error) {
+	path, err := statePath()
+	if err != nil {
+		return nil, err
+	}
+	st := &credentialState{Credentials: map[string]credentialRecord{}}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return st, nil
+		}
+		return nil, fmt.Errorf("cannot read credential state: %w", err)
+	}
+	if len(data) == 0 {
+		return st, nil
+	}
+	if err := json.Unmarshal(data, st); err != nil {
+		return nil, fmt.Errorf("invalid credential state file %s: %w", path, err)
+	}
+	if st.Credentials == nil {
+		st.Credentials = map[string]credentialRecord{}
+	}
+	return st, nil
+}
+
+// saveState writes the per-profile credential state atomically (0600).
+func saveState(st *credentialState) error {
+	path, err := statePath()
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal credential state: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("cannot write credential state: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("cannot save credential state: %w", err)
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -253,6 +253,7 @@ func addServiceCommands() {
 		getEndpointManagerCommand(),
 		getCollectionCommand(),
 		getGCSCommand(),
+		getProjectCommand(),
 		getAPICommand(),
 		getConfigCommand(),
 		getListCommandsCommand(),

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -80,7 +80,7 @@ func TestFlatCommandStructure(t *testing.T) {
 		"ls", "mkdir", "rm", "rename", "stat", "delete", "transfer", "task", "endpoint",
 		"bookmark", "tunnel", "stream-access-point", "endpoint-manager",
 		"group", "search", "flows", "timer", "compute", "api", "config",
-		"collection", "gcs",
+		"collection", "gcs", "project",
 		"list-commands", "version",
 	}
 	for _, name := range wantTopLevel {

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -73,6 +73,7 @@ device-code flow and `identities lookup` performs a real `GetIdentities` call
 | Endpoint set-subscription-id / my-shared-endpoint-list | ✅ | ✅ | Covered (Phase 6) |
 | `list-commands` / `version` | ✅ | ✅ | Covered (Phase 6) |
 | Compute | ❌ (not in Python CLI) | ✅ (endpoint/function/task) | Go-only extension |
+| Project / client / credential management | ❌ (console-only in Python CLI) | ✅ (`project`, `project client`, `project credential` incl. rotation) | Go-only extension |
 
 **JSON output shape (Phase 6):** list commands emit the enveloped service
 document under `-F json` (`{"DATA_TYPE": ..., "DATA": [...]}`), matching the
@@ -134,6 +135,29 @@ The Go CLI exposes a `compute` command tree; the Python CLI has **no** compute
 commands (Globus Compute has its own separate `globus-compute` CLI). The Go
 compute commands are limited by the Compute web API (no list/cancel/run of tasks
 or functions server-side — those require the Globus Compute serialization SDK).
+
+## Project / client / credential management is a Go-only extension
+
+The Go CLI's `project` command tree manages Globus Auth **projects**, their
+registered **clients** (service accounts / app registrations), and client
+**secret credentials** — the developer-console administrative surface. The
+Python `globus-cli` has **no** commands for this (it is web-console only); the
+capability is ported from the standalone `globus-project-manager` tool onto the
+v4 SDK. Highlights:
+
+- `project list/show/create/update/delete` and `project admin list/add/remove`.
+- `project client list/show/create/update/delete` plus `update-redirect-uris`
+  and `update-metadata`.
+- `project credential list/create/delete` plus **rotation** (`rotate`,
+  `list-age`, `process-deletions`) with a transition period. The Globus Auth API
+  has no rotation primitive, so rotation state (linked new/old credentials +
+  scheduled-deletion dates) is tracked in a per-profile local file
+  `~/.globus-cli/credential-state-<profile>.json`.
+
+These commands require the `manage_projects` scope, which the standard `globus
+login` scope set omits; the CLI obtains it via a one-time consent (escalated on
+first use), stored under a dedicated token namespace so it never collides with
+the login token (both live on `auth.globus.org`).
 
 ## Summary
 

--- a/pkg/globusauth/app.go
+++ b/pkg/globusauth/app.go
@@ -354,6 +354,16 @@ func StoreTokens(profile string, now time.Time, tokens ...StoredToken) error {
 // scopes are keyed on a specific endpoint or collection ID rather than a
 // well-known service resource server.
 func ScopedApp(profile, clientID, clientSecret, resourceServer, scope string) (*app.UserApp, error) {
+	return ScopedAppWithNamespace(profile, clientID, clientSecret, resourceServer, scope, "globus-cli")
+}
+
+// ScopedAppWithNamespace is like ScopedApp but stores/reads the consent token
+// under a caller-chosen token-storage namespace. This matters when a dynamic
+// scope shares a resource server with the standard login token (e.g. the
+// auth.globus.org manage_projects scope vs the login's openid/profile/email
+// token): a distinct namespace keeps them from overwriting each other and
+// prevents GetAuthorizer from returning the wrong token.
+func ScopedAppWithNamespace(profile, clientID, clientSecret, resourceServer, scope, namespace string) (*app.UserApp, error) {
 	if clientID == "" {
 		clientID = DefaultClientID
 	}
@@ -361,7 +371,7 @@ func ScopedApp(profile, clientID, clientSecret, resourceServer, scope string) (*
 	if err != nil {
 		return nil, err
 	}
-	store, err := tokenstorage.NewJSONTokenStorageWithNamespace(path, "globus-cli")
+	store, err := tokenstorage.NewJSONTokenStorageWithNamespace(path, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open token storage: %w", err)
 	}
@@ -384,7 +394,14 @@ func ScopedApp(profile, clientID, clientSecret, resourceServer, scope string) (*
 // scope determines what the consent grants (an endpoint's manage_collections or
 // a collection's data_access).
 func ScopedClientConfig(ctx context.Context, profile, clientID, clientSecret, resourceServer, scope string, allowConsent bool) (*core.Config, error) {
-	userApp, err := ScopedApp(profile, clientID, clientSecret, resourceServer, scope)
+	return ScopedClientConfigWithNamespace(ctx, profile, clientID, clientSecret, resourceServer, scope, "globus-cli", allowConsent)
+}
+
+// ScopedClientConfigWithNamespace is ScopedClientConfig with an explicit
+// token-storage namespace (see ScopedAppWithNamespace for why this is needed
+// when a scope shares a resource server with the login token).
+func ScopedClientConfigWithNamespace(ctx context.Context, profile, clientID, clientSecret, resourceServer, scope, namespace string, allowConsent bool) (*core.Config, error) {
+	userApp, err := ScopedAppWithNamespace(profile, clientID, clientSecret, resourceServer, scope, namespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Ports `globus-project-manager` into the CLI as a `project` tree

Brings the standalone Python `globus-project-manager` tool into `globus-go-cli`,
on the v4 SDK. Manages Globus Auth **projects**, their registered **clients**
(service accounts / app registrations), and client **secret credentials** — the
developer-console admin surface the Python `globus-cli` doesn't cover. A Go-only
extension (documented alongside `compute`).

### Commands (GCS-shaped: one top-level tree, nested subgroups)
```
project     list · show · create · update · delete
project admin        list · add · remove
project client       list · show · create · update · delete
                     · update-redirect-uris · update-metadata
project credential   list · create · delete · rotate · list-age · process-deletions
```
`admin add` resolves a username → identity via `GetIdentities`; `admin`
edits `AdminIDs` via `UpdateProject`.

### Auth (the tricky bit)
These need the `manage_projects` scope, which the standard `globus login` scope
set omits. The `project` commands obtain it via a **one-time consent** (escalated
on first use), stored under a **dedicated token-storage namespace** so it never
collides with the login token — both live on the `auth.globus.org` resource
server. Added `globusauth.ScopedClientConfigWithNamespace` for this.

### Rotation / scheduled deletion
The Globus Auth API has no rotation primitive, so `rotate` creates a new
credential and records `rotated_to`/`rotated_from`/`scheduled_deletion` in a
**per-profile local state file** (`~/.globus-cli/credential-state-<profile>.json`);
`process-deletions` later deletes credentials whose scheduled date has passed.
Secrets are shown only on create/rotate (never logged or listed).

### Notes
- Built with 3 parallel subagents (project+admin, client, credential) over
  disjoint files; foundation (client helper, state store, namespaced consent,
  wiring) done in the main session.
- Parity + flat-structure tests assert the new commands.
- Verified: `GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues;
  arg/flag validation clean.