### PR TITLE
feat(collection): cat — GCS HTTPS data-plane file read

### DIFF
--- a/cmd/collection/client.go
+++ b/cmd/collection/client.go
@@ -17,6 +17,7 @@ package collection
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -86,4 +87,38 @@ func getManagerClient(ctx context.Context, endpointID string) (*gcs.CollectionCl
 		return nil, fmt.Errorf("failed to create GCS collection client: %w", err)
 	}
 	return client, nil
+}
+
+// collectionHTTPSToken obtains a raw access token for a specific collection's
+// data-plane `https` scope, escalating consent on first use. Unlike the
+// management scope, data access is a collection scope (URL format, keyed on the
+// collection ID) — so it gets its own per-collection token namespace. Returns
+// the bare access token (no "Bearer " prefix) for the GCS Downloader.
+func collectionHTTPSToken(ctx context.Context, collectionID string) (string, error) {
+	profile := viper.GetString("profile")
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	httpsScope, _ := gcs.CollectionScopes(collectionID)
+	// Namespace per collection so distinct collections' data-access consents
+	// don't overwrite each other (they share the data-access resource server
+	// pattern but are logically independent).
+	namespace := "globus-cli-gcs-https-" + collectionID
+	cfg, err := globusauth.ScopedClientConfigWithNamespace(
+		ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret,
+		collectionID, httpsScope, namespace, true,
+	)
+	if err != nil {
+		return "", fmt.Errorf("could not obtain data-access consent for collection %s: %w", collectionID, err)
+	}
+	if cfg.Authorizer == nil {
+		return "", fmt.Errorf("no authorizer for collection %s data access", collectionID)
+	}
+	header, err := cfg.Authorizer.GetAuthorizationHeader(ctx)
+	if err != nil {
+		return "", fmt.Errorf("could not read data-access token: %w", err)
+	}
+	return strings.TrimPrefix(header, "Bearer "), nil
 }

--- a/cmd/collection/collection.go
+++ b/cmd/collection/collection.go
@@ -39,6 +39,7 @@ manage_collections consent on first use (a paste-code login prompt).`,
 		collectionCreateCmd(),
 		collectionUpdateCmd(),
 		collectionDeleteCmd(),
+		collectionCatCmd(),
 	)
 
 	return collectionCmd

--- a/cmd/collection/data.go
+++ b/cmd/collection/data.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package collection
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/authorizers"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/core"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/gcs"
+)
+
+// collectionCatCmd returns the `collection cat` command: read a file's contents
+// from an HTTPS-enabled GCSv5 collection's data plane.
+func collectionCatCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "cat ENDPOINT_ID COLLECTION_ID PATH",
+		Short: "Print a file's contents from an HTTPS-enabled collection",
+		Long: `Read and print a file from a Globus Connect Server v5 collection over its
+HTTPS data-plane interface.
+
+The collection must have HTTPS enabled (an https_url). This is a data-plane
+operation: it requires the collection's data-access consent, which the CLI
+escalates on first use (separately from the endpoint's manage_collections
+consent used by the other collection commands).
+
+Examples:
+  globus collection cat ENDPOINT_ID COLLECTION_ID /path/to/file.txt`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return catCollectionFile(cmd, args[0], args[1], args[2])
+		},
+	}
+}
+
+// catCollectionFile reads COLLECTION_ID:PATH over HTTPS and writes it to stdout.
+func catCollectionFile(cmd *cobra.Command, endpointID, collectionID, path string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Resolve the collection's HTTPS data-plane base URL via the GCS Manager.
+	managerClient, err := getManagerClient(ctx, endpointID)
+	if err != nil {
+		return err
+	}
+	coll, err := managerClient.GetCollection(ctx, collectionID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to look up collection %s: %w", collectionID, err)
+	}
+	if coll.HTTPSURL == "" {
+		return fmt.Errorf("collection %s does not have HTTPS enabled (no https_url); cannot read files over HTTPS", collectionID)
+	}
+
+	// Obtain a data-access (https) token for this collection.
+	token, err := collectionHTTPSToken(ctx, collectionID)
+	if err != nil {
+		return err
+	}
+
+	// Build the file URI: <https_url>/<path> (single slash join).
+	fileURI := strings.TrimRight(coll.HTTPSURL, "/") + "/" + strings.TrimPrefix(path, "/")
+
+	// A CollectionClient is required to construct the Downloader; the raw token
+	// passed to NewDownloaderWithToken is what actually authorizes the
+	// data-plane request.
+	dlClient, err := gcs.NewCollectionClient(ctx, coll.HTTPSURL, collectionID,
+		&core.Config{Authorizer: authorizers.NewAccessTokenAuthorizer(token)})
+	if err != nil {
+		return fmt.Errorf("failed to create data-plane client: %w", err)
+	}
+	downloader := gcs.NewDownloaderWithToken(dlClient, token)
+	defer func() { _ = downloader.Close() }()
+
+	data, err := downloader.ReadFile(ctx, fileURI)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", fileURI, err)
+	}
+
+	_, err = cmd.OutOrStdout().Write(data)
+	return err
+}

--- a/cmd/parity_test.go
+++ b/cmd/parity_test.go
@@ -87,6 +87,7 @@ func TestCommandParity(t *testing.T) {
 		// GCSv5 collections + manager admin.
 		"collection list", "collection show", "collection create", "collection delete",
 		"gcs info", "gcs storage-gateway list", "gcs role list", "gcs role create",
+		"collection cat",
 		// Project / client / credential management (globus-project-manager port).
 		"project list", "project create", "project admin add",
 		"project client list", "project client create",

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -123,9 +123,10 @@ Still available in the SDK but not yet wired:
      scope (`gcs.EndpointManageCollectionsScope`, SDK v4.8.1-3).
   `collection list/show/create/update/delete` and `gcs info` +
   `storage-gateway`/`role` subcommands are wired. Each takes the owning
-  `ENDPOINT_ID` as its first argument. Data-plane operations that need a
-  collection's `data_access`/`https` scope (e.g. GCS-hosted file listing) are a
-  possible future addition using the same consent-escalation helper.
+  `ENDPOINT_ID` as its first argument. `collection cat ENDPOINT_ID
+  COLLECTION_ID PATH` reads a file over the collection's HTTPS data plane,
+  using the collection's `https` scope (a separate per-collection data-access
+  consent, escalated on first use).
 - **GCP (Globus Connect Personal)** — local-agent management; not an SDK API
   (out of scope).
 
@@ -171,7 +172,7 @@ raw passthrough, and the `list-commands`/`version` meta commands — plus a
 compute extension the Python CLI lacks.
 
 The only remaining item is **GCP (Globus Connect Personal)** — local-agent
-management with no SDK API, out of scope. Optional future polish: GCS data-plane
-file operations (e.g. `ls` over a collection's `https` scope) via the same
-consent-escalation helper, and richer per-command flag coverage to match every
-Python option.
+management with no SDK API, out of scope. GCS data-plane file access is started
+(`collection cat`); more data-plane operations (e.g. HTTPS directory listing)
+could follow using the same per-collection `https`-scope consent. Optional
+future polish: richer per-command flag coverage to match every Python option.


### PR DESCRIPTION
Adds `globus collection cat ENDPOINT_ID COLLECTION_ID PATH` — the first
data-plane operation for GCS collections.

It resolves the collection's `https_url` via the GCS Manager, obtains the
collection's `https` **data-access** token (a separate per-collection consent,
escalated on first use and stored under its own token namespace so it doesn't
collide with the endpoint's `manage_collections` token), and streams the file
to stdout via the SDK's `gcs.Downloader`.

- `cmd/collection/client.go` gains `collectionHTTPSToken(ctx, collectionID)`,
  which mints the `https`-scoped token and returns the bare access token for the
  Downloader.

This is the "GCS data-plane" follow-up we'd deferred. Further data-plane ops
(e.g. HTTPS directory listing) could follow with the same helper.

Verified: `GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues;
parity test asserts `collection cat`.