### PR TITLE
feat: flag parity with the Python globus CLI across the command tree

### DIFF
--- a/cmd/auth/identities.go
+++ b/cmd/auth/identities.go
@@ -60,6 +60,7 @@ func identitiesLookupCmd() *cobra.Command {
 	var username string
 	var email string
 	var id string
+	var provision bool
 
 	cmd := &cobra.Command{
 		Use:   "lookup",
@@ -97,7 +98,7 @@ provided criteria.`,
 			// Build the lookup options. ID lookups query by identity ID;
 			// username/email lookups query by username (email is a username in
 			// Globus Auth).
-			opts := &sdkauth.GetIdentitiesOptions{}
+			opts := &sdkauth.GetIdentitiesOptions{Provision: provision}
 			switch {
 			case id != "":
 				opts.IDs = []string{id}
@@ -147,6 +148,7 @@ provided criteria.`,
 	cmd.Flags().StringVar(&username, "username", "", "Look up by username")
 	cmd.Flags().StringVar(&email, "email", "", "Look up by email")
 	cmd.Flags().StringVar(&id, "id", "", "Look up by identity ID")
+	cmd.Flags().BoolVar(&provision, "provision", false, "Create identities if they do not exist (only affects username lookups)")
 
 	return cmd
 }

--- a/cmd/auth/session.go
+++ b/cmd/auth/session.go
@@ -52,6 +52,7 @@ func sessionUpdateCmd() *cobra.Command {
 		domain     string
 		policies   []string
 		mfa        bool
+		scopes     []string
 	)
 	cmd := &cobra.Command{
 		Use:   "update",
@@ -79,9 +80,11 @@ policies, or MFA. This starts a browser/paste-code login flow like 'login'.`,
 				sp.RequiredSingleDomain = []string{domain}
 			}
 
-			// Re-auth for the auth resource server (openid identity scopes).
+			// Re-auth for the auth resource server (openid identity scopes),
+			// plus any additional scopes requested with --scope.
 			scope, _ := globusauth.Scope(globusauth.ServiceAuth)
-			if _, err := globusauth.SessionLogin(cmd.Context(), profile, clientID, clientSecret, []string{scope}, sp); err != nil {
+			reqScopes := append([]string{scope}, scopes...)
+			if _, err := globusauth.SessionLogin(cmd.Context(), profile, clientID, clientSecret, reqScopes, sp); err != nil {
 				return fmt.Errorf("session update failed: %w", err)
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "Session updated.")
@@ -92,6 +95,7 @@ policies, or MFA. This starts a browser/paste-code login flow like 'login'.`,
 	cmd.Flags().StringVar(&domain, "domain", "", "Require an identity from this single domain (mutually exclusive with --identity)")
 	cmd.Flags().StringSliceVar(&policies, "policy", nil, "Comma-separated authentication policy UUIDs to satisfy")
 	cmd.Flags().BoolVar(&mfa, "mfa", false, "Require multi-factor authentication")
+	cmd.Flags().StringArrayVar(&scopes, "scope", nil, "One or more additional scope strings to request during authentication (repeatable)")
 	return cmd
 }
 
@@ -174,9 +178,9 @@ session and when each authenticated.`,
 			sort.Strings(ids)
 
 			type row struct {
-				IdentityID     string
+				IdentityID      string
 				AuthenticatedAt string
-				MFA            bool
+				MFA             bool
 			}
 			rows := make([]row, 0, len(ids))
 			for _, id := range ids {

--- a/cmd/auth/whoami.go
+++ b/cmd/auth/whoami.go
@@ -11,7 +11,11 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	sdkauth "github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
 )
+
+var whoamiLinkedIdentities bool
 
 // WhoamiCmd returns the whoami command
 func WhoamiCmd() *cobra.Command {
@@ -24,9 +28,14 @@ func WhoamiCmd() *cobra.Command {
 This command shows details about your Globus identity based on your
 current tokens.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if whoamiLinkedIdentities {
+				return whoamiLinked(cmd)
+			}
 			return whoami(cmd)
 		},
 	}
+
+	whoamiCmd.Flags().BoolVar(&whoamiLinkedIdentities, "linked-identities", false, "Also show identities linked to the currently logged-in primary identity")
 
 	return whoamiCmd
 }
@@ -68,4 +77,43 @@ func whoami(cmd *cobra.Command) error {
 	}
 
 	return nil
+}
+
+// whoamiLinked shows the identities linked to the caller's primary identity by
+// introspecting the stored auth token with include=identity_set_detail.
+func whoamiLinked(cmd *cobra.Command) error {
+	profile := viper.GetString("profile")
+
+	td, err := globusauth.TokenFor(profile, globusauth.ServiceAuth)
+	if err != nil {
+		return fmt.Errorf("not logged in: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Introspection authenticates the client with Basic auth.
+	authClient, err := newRevokeAuthClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create auth client: %w", err)
+	}
+
+	intro, err := authClient.IntrospectToken(ctx, td.AccessToken, &sdkauth.IntrospectOptions{Include: "identity_set_detail"})
+	if err != nil {
+		return fmt.Errorf("failed to introspect token: %w", err)
+	}
+
+	format := viper.GetString("format")
+	formatter := output.NewFormatter(format, cmd.OutOrStdout())
+	if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+		return formatter.FormatOutput(intro.IdentitySetDetail, nil)
+	}
+
+	if len(intro.IdentitySetDetail) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No linked identities found.")
+		return nil
+	}
+
+	headers := []string{"ID", "Username", "Name", "Email", "IdentityProvider"}
+	return formatter.FormatOutput(intro.IdentitySetDetail, headers)
 }

--- a/cmd/collection/collection.go
+++ b/cmd/collection/collection.go
@@ -4,6 +4,7 @@ package collection
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -47,16 +48,40 @@ manage_collections consent on first use (a paste-code login prompt).`,
 
 // Options for collection listing and mutation.
 var (
-	collectionMappedID     string
-	collectionPageSize     int
-	collectionType         string
-	collectionDisplayName  string
-	collectionStorageGWID  string
-	collectionBasePath     string
-	collectionIdentityID   string
-	collectionPublic       bool
-	collectionDescription  string
-	collectionOrganization string
+	collectionMappedID      string
+	collectionPageSize      int
+	collectionLimit         int
+	collectionFilter        []string
+	collectionInclPrivate   bool
+	collectionType          string
+	collectionDisplayName   string
+	collectionStorageGWID   string
+	collectionBasePath      string
+	collectionIdentityID    string
+	collectionUserCredID    string
+	collectionPublic        bool
+	collectionPrivate       bool
+	collectionDescription   string
+	collectionOrganization  string
+	collectionDepartment    string
+	collectionContactEmail  string
+	collectionContactInfo   string
+	collectionInfoLink      string
+	collectionKeywords      []string
+	collectionForceEnc      bool
+	collectionNoForceEnc    bool
+	collectionDefaultDir    string
+	collectionDomainName    string
+	collectionUserMessage   string
+	collectionUserMsgLink   string
+	collectionVerify        string
+	collectionEnableHTTPS   bool
+	collectionDisableHTTPS  bool
+	collectionAllowGuest    bool
+	collectionNoAllowGuest  bool
+	collectionShareRestrict string
+	collectionShareAllow    []string
+	collectionShareDeny     []string
 )
 
 // collectionListCmd returns the collection list command.
@@ -74,14 +99,17 @@ Optionally filter to the guest collections of a single mapped collection.`,
 	}
 
 	cmd.Flags().StringVar(&collectionMappedID, "mapped-collection-id", "", "Filter to guest collections of this mapped collection")
-	cmd.Flags().IntVar(&collectionPageSize, "page-size", 100, "Maximum number of collections to return")
+	cmd.Flags().StringSliceVar(&collectionFilter, "filter", nil, "Filter results to categories of collections (mapped-collections, guest-collections, managed-by-me, created-by-me); may be given multiple times")
+	cmd.Flags().BoolVar(&collectionInclPrivate, "include-private-policies", false, "Include private policies (requires administrator role)")
+	cmd.Flags().IntVar(&collectionLimit, "limit", 25, "Maximum number of collections to return")
+	cmd.Flags().IntVar(&collectionPageSize, "page-size", 100, "GCS Manager page size")
 
 	return cmd
 }
 
 // collectionShowCmd returns the collection show command.
 func collectionShowCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "show ENDPOINT_ID COLLECTION_ID",
 		Short: "Show collection details",
 		Long:  `Show detailed information about a collection on the given endpoint's GCS Manager.`,
@@ -90,6 +118,10 @@ func collectionShowCmd() *cobra.Command {
 			return showCollection(cmd, args[0], args[1])
 		},
 	}
+
+	cmd.Flags().BoolVar(&collectionInclPrivate, "include-private-policies", false, "Include private policies (requires administrator role)")
+
+	return cmd
 }
 
 // collectionCreateCmd returns the collection create command.
@@ -110,12 +142,33 @@ Mapped collections require --storage-gateway-id; guest collections require
 	cmd.Flags().StringVar(&collectionType, "type", "", "Collection type: mapped or guest (required)")
 	cmd.Flags().StringVar(&collectionDisplayName, "display-name", "", "Display name for the collection (required)")
 	cmd.Flags().StringVar(&collectionStorageGWID, "storage-gateway-id", "", "Storage gateway ID (required for mapped collections)")
-	cmd.Flags().StringVar(&collectionBasePath, "base-path", "", "Collection base path")
+	cmd.Flags().StringVar(&collectionBasePath, "base-path", "", "The location within the storage gateway where the collection is rooted")
 	cmd.Flags().StringVar(&collectionMappedID, "mapped-collection-id", "", "Mapped collection ID (for guest collections)")
-	cmd.Flags().StringVar(&collectionIdentityID, "identity-id", "", "Identity ID that owns the collection")
-	cmd.Flags().BoolVar(&collectionPublic, "public", false, "Make the collection publicly visible")
-	cmd.Flags().StringVar(&collectionDescription, "description", "", "Description of the collection")
+	cmd.Flags().StringVar(&collectionUserCredID, "user-credential-id", "", "Registered local user credential to associate with a guest collection")
+	cmd.Flags().StringVar(&collectionIdentityID, "identity-id", "", "User who should own the collection (defaults to the current user)")
+	cmd.Flags().BoolVar(&collectionPublic, "public", false, "Set the collection to be public")
+	cmd.Flags().BoolVar(&collectionPrivate, "private", false, "Set the collection to be private")
+	cmd.Flags().StringVar(&collectionDescription, "description", "", "Description for the collection")
 	cmd.Flags().StringVar(&collectionOrganization, "organization", "", "Organization for the collection")
+	cmd.Flags().StringVar(&collectionDepartment, "department", "", "Department which operates the collection")
+	cmd.Flags().StringVar(&collectionContactEmail, "contact-email", "", "Contact email for the collection")
+	cmd.Flags().StringVar(&collectionContactInfo, "contact-info", "", "Contact info for the collection")
+	cmd.Flags().StringVar(&collectionInfoLink, "info-link", "", "Link for info about the collection")
+	cmd.Flags().StringSliceVar(&collectionKeywords, "keywords", nil, "Comma separated list of keywords to help searches for the collection")
+	cmd.Flags().BoolVar(&collectionForceEnc, "force-encryption", false, "Force the collection to encrypt transfers")
+	cmd.Flags().BoolVar(&collectionNoForceEnc, "no-force-encryption", false, "Do not force the collection to encrypt transfers")
+	cmd.Flags().StringVar(&collectionDefaultDir, "default-directory", "", "Default directory when browsing or executing tasks on the collection")
+	cmd.Flags().StringVar(&collectionDomainName, "domain-name", "", "DNS host name for the collection (mapped collections only)")
+	cmd.Flags().StringVar(&collectionUserMessage, "user-message", "", "A message for clients to display to users when interacting with this collection")
+	cmd.Flags().StringVar(&collectionUserMsgLink, "user-message-link", "", "Link to additional messaging for clients to display to users")
+	cmd.Flags().StringVar(&collectionVerify, "verify", "", "File integrity verification policy: force, disable, or default")
+	cmd.Flags().BoolVar(&collectionEnableHTTPS, "enable-https", false, "Explicitly enable HTTPS support")
+	cmd.Flags().BoolVar(&collectionDisableHTTPS, "disable-https", false, "Explicitly disable HTTPS support")
+	cmd.Flags().BoolVar(&collectionAllowGuest, "allow-guest-collections", false, "Allow guest collections on this mapped collection")
+	cmd.Flags().BoolVar(&collectionNoAllowGuest, "no-allow-guest-collections", false, "Disallow guest collections on this mapped collection")
+	cmd.Flags().StringVar(&collectionShareRestrict, "sharing-restrict-paths", "", "JSON path restrictions for sharing on guest collections (mapped collections only)")
+	cmd.Flags().StringArrayVar(&collectionShareAllow, "sharing-user-allow", nil, "Connector-specific username allowed to create guest collections; may be given multiple times")
+	cmd.Flags().StringArrayVar(&collectionShareDeny, "sharing-user-deny", nil, "Connector-specific username denied permission to create guest collections; may be given multiple times")
 	_ = cmd.MarkFlagRequired("type")
 	_ = cmd.MarkFlagRequired("display-name")
 
@@ -136,10 +189,30 @@ Only the fields you supply as flags are changed.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&collectionDisplayName, "display-name", "", "New display name")
-	cmd.Flags().StringVar(&collectionDescription, "description", "", "New description")
-	cmd.Flags().StringVar(&collectionOrganization, "organization", "", "New organization")
-	cmd.Flags().BoolVar(&collectionPublic, "public", false, "Set public visibility")
+	cmd.Flags().StringVar(&collectionDisplayName, "display-name", "", "Name for the collection")
+	cmd.Flags().StringVar(&collectionDescription, "description", "", "Description for the collection")
+	cmd.Flags().StringVar(&collectionOrganization, "organization", "", "Organization for the collection")
+	cmd.Flags().StringVar(&collectionDepartment, "department", "", "Department which operates the collection")
+	cmd.Flags().StringVar(&collectionContactEmail, "contact-email", "", "Contact email for the collection")
+	cmd.Flags().StringVar(&collectionContactInfo, "contact-info", "", "Contact info for the collection")
+	cmd.Flags().StringVar(&collectionInfoLink, "info-link", "", "Link for info about the collection")
+	cmd.Flags().StringSliceVar(&collectionKeywords, "keywords", nil, "Comma separated list of keywords to help searches for the collection")
+	cmd.Flags().BoolVar(&collectionPublic, "public", false, "Set the collection to be public")
+	cmd.Flags().BoolVar(&collectionPrivate, "private", false, "Set the collection to be private")
+	cmd.Flags().BoolVar(&collectionForceEnc, "force-encryption", false, "Force the collection to encrypt transfers")
+	cmd.Flags().BoolVar(&collectionNoForceEnc, "no-force-encryption", false, "Do not force the collection to encrypt transfers")
+	cmd.Flags().StringVar(&collectionDefaultDir, "default-directory", "", "Default directory when browsing or executing tasks on the collection")
+	cmd.Flags().StringVar(&collectionDomainName, "domain-name", "", "DNS host name for the collection (mapped collections only)")
+	cmd.Flags().StringVar(&collectionUserMessage, "user-message", "", "A message for clients to display to users when interacting with this collection")
+	cmd.Flags().StringVar(&collectionUserMsgLink, "user-message-link", "", "Link to additional messaging for clients to display to users")
+	cmd.Flags().StringVar(&collectionVerify, "verify", "", "File integrity verification policy: force, disable, or default")
+	cmd.Flags().BoolVar(&collectionEnableHTTPS, "enable-https", false, "Explicitly enable HTTPS support")
+	cmd.Flags().BoolVar(&collectionDisableHTTPS, "disable-https", false, "Explicitly disable HTTPS support")
+	cmd.Flags().BoolVar(&collectionAllowGuest, "allow-guest-collections", false, "Allow guest collections on this mapped collection")
+	cmd.Flags().BoolVar(&collectionNoAllowGuest, "no-allow-guest-collections", false, "Disallow guest collections on this mapped collection")
+	cmd.Flags().StringVar(&collectionShareRestrict, "sharing-restrict-paths", "", "JSON path restrictions for sharing on guest collections (mapped collections only)")
+	cmd.Flags().StringArrayVar(&collectionShareAllow, "sharing-user-allow", nil, "Connector-specific username allowed to create guest collections; may be given multiple times")
+	cmd.Flags().StringArrayVar(&collectionShareDeny, "sharing-user-deny", nil, "Connector-specific username denied permission to create guest collections; may be given multiple times")
 
 	return cmd
 }
@@ -167,9 +240,20 @@ func listCollections(cmd *cobra.Command, endpointID string) error {
 		return err
 	}
 
+	// --limit sets the page size the user cares about; --page-size is the raw
+	// GCS Manager page size. Prefer --limit when explicitly set.
+	pageSize := collectionPageSize
+	if cmd.Flags().Changed("limit") {
+		pageSize = collectionLimit
+	}
+
 	opts := &gcs.ListCollectionsOptions{
 		MappedCollectionID: collectionMappedID,
-		PageSize:           collectionPageSize,
+		PageSize:           pageSize,
+		Filter:             collectionFilter,
+	}
+	if collectionInclPrivate {
+		opts.Include = append(opts.Include, "private_policies")
 	}
 
 	resp, err := client.ListCollections(ctx, opts)
@@ -214,7 +298,14 @@ func showCollection(cmd *cobra.Command, endpointID, collectionID string) error {
 		return err
 	}
 
-	col, err := client.GetCollection(ctx, collectionID, nil)
+	var getOpts *gcs.GetCollectionOptions
+	if collectionInclPrivate {
+		getOpts = &gcs.GetCollectionOptions{
+			QueryParams: map[string]string{"include": "private_policies"},
+		}
+	}
+
+	col, err := client.GetCollection(ctx, collectionID, getOpts)
 	if err != nil {
 		return fmt.Errorf("failed to get collection: %w", err)
 	}
@@ -278,20 +369,13 @@ func createCollection(cmd *cobra.Command, endpointID string) error {
 	if collectionMappedID != "" {
 		doc.MappedCollectionID = collectionMappedID
 	}
+	if collectionUserCredID != "" {
+		doc.UserCredentialID = collectionUserCredID
+	}
 	if collectionIdentityID != "" {
 		doc.IdentityID = collectionIdentityID
 	}
-	if collectionOrganization != "" {
-		doc.Organization = collectionOrganization
-	}
-	if cmd.Flags().Changed("public") {
-		public := collectionPublic
-		doc.Public = &public
-	}
-	if cmd.Flags().Changed("description") {
-		desc := collectionDescription
-		doc.Description = &desc
-	}
+	applyCollectionFlags(cmd, doc)
 
 	col, err := client.CreateCollection(ctx, doc)
 	if err != nil {
@@ -313,20 +397,7 @@ func updateCollection(cmd *cobra.Command, endpointID, collectionID string) error
 	}
 
 	doc := &gcs.CollectionDocument{}
-	if cmd.Flags().Changed("display-name") {
-		doc.DisplayName = collectionDisplayName
-	}
-	if cmd.Flags().Changed("organization") {
-		doc.Organization = collectionOrganization
-	}
-	if cmd.Flags().Changed("public") {
-		public := collectionPublic
-		doc.Public = &public
-	}
-	if cmd.Flags().Changed("description") {
-		desc := collectionDescription
-		doc.Description = &desc
-	}
+	applyCollectionFlags(cmd, doc)
 
 	if _, err := client.UpdateCollection(ctx, collectionID, doc); err != nil {
 		return fmt.Errorf("failed to update collection: %w", err)
@@ -352,4 +423,110 @@ func deleteCollection(cmd *cobra.Command, endpointID, collectionID string) error
 
 	fmt.Printf("Deleted collection %s\n", collectionID)
 	return nil
+}
+
+// strPtr returns a pointer to s.
+func strPtr(s string) *string { return &s }
+
+// boolPtr returns a pointer to b.
+func boolPtr(b bool) *bool { return &b }
+
+// applyCollectionFlags sets the shared CollectionDocument fields from the flags
+// the user explicitly changed. It is used by both create and update so the two
+// commands accept the same field set (matching the Python CLI's shared options).
+func applyCollectionFlags(cmd *cobra.Command, doc *gcs.CollectionDocument) {
+	if cmd.Flags().Changed("display-name") {
+		doc.DisplayName = collectionDisplayName
+	}
+	if cmd.Flags().Changed("description") {
+		doc.Description = strPtr(collectionDescription)
+	}
+	if cmd.Flags().Changed("organization") {
+		doc.Organization = collectionOrganization
+	}
+	if cmd.Flags().Changed("department") {
+		doc.Department = strPtr(collectionDepartment)
+	}
+	if cmd.Flags().Changed("contact-email") {
+		doc.ContactEmail = strPtr(collectionContactEmail)
+	}
+	if cmd.Flags().Changed("contact-info") {
+		doc.ContactInfo = strPtr(collectionContactInfo)
+	}
+	if cmd.Flags().Changed("info-link") {
+		doc.InfoLink = strPtr(collectionInfoLink)
+	}
+	if cmd.Flags().Changed("keywords") {
+		doc.Keywords = collectionKeywords
+	}
+	if cmd.Flags().Changed("default-directory") {
+		doc.DefaultDirectory = collectionDefaultDir
+	}
+	if cmd.Flags().Changed("domain-name") {
+		doc.DomainName = collectionDomainName
+	}
+	if cmd.Flags().Changed("user-message") {
+		doc.UserMessage = strPtr(collectionUserMessage)
+	}
+	if cmd.Flags().Changed("user-message-link") {
+		doc.UserMessageLink = strPtr(collectionUserMsgLink)
+	}
+
+	// --public / --private
+	if cmd.Flags().Changed("public") {
+		doc.Public = boolPtr(collectionPublic)
+	}
+	if collectionPrivate {
+		doc.Public = boolPtr(false)
+	}
+
+	// --force-encryption / --no-force-encryption
+	if cmd.Flags().Changed("force-encryption") {
+		doc.ForceEncryption = boolPtr(collectionForceEnc)
+	}
+	if collectionNoForceEnc {
+		doc.ForceEncryption = boolPtr(false)
+	}
+
+	// --enable-https / --disable-https
+	if cmd.Flags().Changed("enable-https") {
+		doc.EnableHTTPS = boolPtr(collectionEnableHTTPS)
+	}
+	if collectionDisableHTTPS {
+		doc.EnableHTTPS = boolPtr(false)
+	}
+
+	// --allow-guest-collections / --no-allow-guest-collections (mapped only)
+	if cmd.Flags().Changed("allow-guest-collections") {
+		doc.AllowGuestCollections = boolPtr(collectionAllowGuest)
+	}
+	if collectionNoAllowGuest {
+		doc.AllowGuestCollections = boolPtr(false)
+	}
+
+	// --verify [force|disable|default]
+	if cmd.Flags().Changed("verify") {
+		switch collectionVerify {
+		case "force":
+			doc.ForceVerify = boolPtr(true)
+			doc.DisableVerify = boolPtr(false)
+		case "disable":
+			doc.DisableVerify = boolPtr(true)
+			doc.ForceVerify = boolPtr(false)
+		case "default":
+			doc.ForceVerify = boolPtr(false)
+			doc.DisableVerify = boolPtr(false)
+		}
+	}
+
+	// Sharing controls (mapped collections only).
+	if cmd.Flags().Changed("sharing-user-allow") {
+		doc.SharingUsersAllow = collectionShareAllow
+	}
+	if cmd.Flags().Changed("sharing-user-deny") {
+		doc.SharingUsersDeny = collectionShareDeny
+	}
+	if cmd.Flags().Changed("sharing-restrict-paths") {
+		doc.SharingRestrictPaths = json.RawMessage(collectionShareRestrict)
+	}
 }

--- a/cmd/flows/create.go
+++ b/cmd/flows/create.go
@@ -16,10 +16,19 @@ import (
 var (
 	createTitle          string
 	createDescription    string
+	createSubtitle       string
 	createDefinitionFile string
 	createSchemaFile     string
 	createKeywords       []string
 	createPublic         bool
+
+	createAdministrators []string
+	createStarters       []string
+	createViewers        []string
+	createRunManagers    []string
+	createRunMonitors    []string
+	createSubscriptionID string
+	createAuthPolicyID   string
 
 	// Authentication policy flags (Python SDK v4.1.0)
 	createHighAssurance   bool
@@ -57,10 +66,20 @@ Examples:
 func init() {
 	CreateCmd.Flags().StringVar(&createTitle, "title", "", "Flow title (required)")
 	CreateCmd.Flags().StringVar(&createDescription, "description", "", "Flow description")
+	CreateCmd.Flags().StringVar(&createSubtitle, "subtitle", "", "A concise summary of the flow's purpose")
 	CreateCmd.Flags().StringVar(&createDefinitionFile, "definition-file", "", "Path to flow definition JSON file (required)")
 	CreateCmd.Flags().StringVar(&createSchemaFile, "schema-file", "", "Path to input schema JSON file")
 	CreateCmd.Flags().StringSliceVar(&createKeywords, "keywords", []string{}, "Comma-separated keywords")
 	CreateCmd.Flags().BoolVar(&createPublic, "public", false, "Make flow publicly visible")
+
+	// Principal role lists (repeatable). Backed by FlowCreate.
+	CreateCmd.Flags().StringArrayVar(&createAdministrators, "administrator", nil, "A principal that may administer the flow (repeatable)")
+	CreateCmd.Flags().StringArrayVar(&createStarters, "starter", nil, "A principal that may start a run of the flow (repeatable); use \"all_authenticated_users\" for any user")
+	CreateCmd.Flags().StringArrayVar(&createViewers, "viewer", nil, "A principal that may view the flow (repeatable); use \"public\" to make it visible to everyone")
+	CreateCmd.Flags().StringArrayVar(&createRunManagers, "run-manager", nil, "A principal that may manage the flow's runs (repeatable)")
+	CreateCmd.Flags().StringArrayVar(&createRunMonitors, "run-monitor", nil, "A principal that may monitor the flow's runs (repeatable)")
+	CreateCmd.Flags().StringVar(&createSubscriptionID, "subscription-id", "", "Set a subscription_id for the flow, marking it as subscription tier")
+	CreateCmd.Flags().StringVar(&createAuthPolicyID, "authentication-policy-id", "", "A Globus Auth authentication policy ID to enforce on the flow (must require high-assurance)")
 
 	// Authentication policy flags (Python SDK v4.1.0)
 	CreateCmd.Flags().BoolVar(&createHighAssurance, "high-assurance", false, "Require high-assurance authentication for flow runs")
@@ -108,11 +127,19 @@ func runFlowsCreate(cmd *cobra.Command, args []string) error {
 
 	// Build create request
 	request := &flows.FlowCreate{
-		Title:       createTitle,
-		Description: createDescription,
-		Definition:  definition,
-		InputSchema: inputSchema,
-		Keywords:    createKeywords,
+		Title:                  createTitle,
+		Description:            createDescription,
+		Subtitle:               createSubtitle,
+		Definition:             definition,
+		InputSchema:            inputSchema,
+		Keywords:               createKeywords,
+		FlowAdministrators:     createAdministrators,
+		FlowStarters:           createStarters,
+		FlowViewers:            createViewers,
+		RunManagers:            createRunManagers,
+		RunMonitors:            createRunMonitors,
+		SubscriptionID:         createSubscriptionID,
+		AuthenticationPolicyID: createAuthPolicyID,
 	}
 
 	// Create flow

--- a/cmd/flows/list.go
+++ b/cmd/flows/list.go
@@ -15,10 +15,11 @@ import (
 )
 
 var (
-	listLimit   int
-	listOffset  int
-	listFilter  string
-	listOrderBy string
+	listLimit      int
+	listOffset     int
+	listFilter     string
+	listFilterRole string
+	listOrderBy    string
 )
 
 // ListCmd represents the flows list command
@@ -53,6 +54,7 @@ func init() {
 	_ = ListCmd.Flags().MarkDeprecated("limit", "list_flows is marker-paginated")
 	_ = ListCmd.Flags().MarkDeprecated("offset", "list_flows is marker-paginated")
 	ListCmd.Flags().StringVar(&listFilter, "filter", "", "Filter flows by text")
+	ListCmd.Flags().StringVar(&listFilterRole, "filter-role", "", "Filter by the caller's role (flow_viewer, flow_starter, flow_administrator, flow_owner, run_manager, run_monitor)")
 	ListCmd.Flags().StringVar(&listOrderBy, "orderby", "created_at", "Order results by field (created_at, updated_at, title)")
 }
 
@@ -75,6 +77,9 @@ func runFlowsList(cmd *cobra.Command, args []string) error {
 	}
 	if listFilter != "" {
 		options.FilterFulltext = listFilter
+	}
+	if listFilterRole != "" {
+		options.FilterRoles = []string{listFilterRole}
 	}
 
 	// List flows

--- a/cmd/flows/run_list.go
+++ b/cmd/flows/run_list.go
@@ -15,11 +15,12 @@ import (
 )
 
 var (
-	runListLimit   int
-	runListOffset  int
-	runListFlowID  string
-	runListStatus  string
-	runListOrderBy string
+	runListLimit      int
+	runListOffset     int
+	runListFlowID     string
+	runListFilterRole string
+	runListStatus     string
+	runListOrderBy    string
 )
 
 // RunListCmd represents the flows run list command
@@ -56,6 +57,7 @@ func init() {
 	_ = RunListCmd.Flags().MarkDeprecated("limit", "list_runs is marker-paginated")
 	_ = RunListCmd.Flags().MarkDeprecated("offset", "list_runs is marker-paginated")
 	RunListCmd.Flags().StringVar(&runListFlowID, "flow-id", "", "Filter by flow ID")
+	RunListCmd.Flags().StringVar(&runListFilterRole, "filter-role", "", "Filter by the caller's role (run_owner, run_manager, run_monitor, flow_run_manager, flow_run_monitor)")
 	RunListCmd.Flags().StringVar(&runListStatus, "status", "", "Filter by status (ACTIVE, SUCCEEDED, FAILED, INACTIVE)")
 	// Runs are ordered by run fields (e.g. start_time); created_at is a flow
 	// field and is rejected here.
@@ -78,6 +80,9 @@ func runFlowsRunList(cmd *cobra.Command, args []string) error {
 	options := &flows.ListRunsOptions{}
 	if runListFlowID != "" {
 		options.FilterFlowID = []string{runListFlowID}
+	}
+	if runListFilterRole != "" {
+		options.FilterRoles = []string{runListFilterRole}
 	}
 
 	// List runs

--- a/cmd/flows/run_update.go
+++ b/cmd/flows/run_update.go
@@ -13,8 +13,10 @@ import (
 )
 
 var (
-	runUpdateLabel string
-	runUpdateTags  []string
+	runUpdateLabel    string
+	runUpdateTags     []string
+	runUpdateManagers []string
+	runUpdateMonitors []string
 )
 
 // RunUpdateCmd represents the flows run update command
@@ -43,7 +45,9 @@ Examples:
 
 func init() {
 	RunUpdateCmd.Flags().StringVar(&runUpdateLabel, "label", "", "New label for the run")
-	RunUpdateCmd.Flags().StringSliceVar(&runUpdateTags, "tags", []string{}, "New comma-separated tags")
+	RunUpdateCmd.Flags().StringSliceVar(&runUpdateTags, "tags", []string{}, "New comma-separated tags (empty string clears)")
+	RunUpdateCmd.Flags().StringSliceVar(&runUpdateManagers, "managers", nil, "Comma-separated principals that may manage the run (empty string clears)")
+	RunUpdateCmd.Flags().StringSliceVar(&runUpdateMonitors, "monitors", nil, "Comma-separated principals that may monitor the run (empty string clears)")
 }
 
 func runFlowsRunUpdate(cmd *cobra.Command, args []string) error {
@@ -60,9 +64,18 @@ func runFlowsRunUpdate(cmd *cobra.Command, args []string) error {
 		request.Tags = runUpdateTags
 	}
 
+	if cmd.Flags().Changed("managers") {
+		request.RunManagers = runUpdateManagers
+	}
+
+	if cmd.Flags().Changed("monitors") {
+		request.RunMonitors = runUpdateMonitors
+	}
+
 	// Validate that at least one field is being updated
-	if !cmd.Flags().Changed("label") && !cmd.Flags().Changed("tags") {
-		return fmt.Errorf("at least one of --label or --tags must be specified")
+	if !cmd.Flags().Changed("label") && !cmd.Flags().Changed("tags") &&
+		!cmd.Flags().Changed("managers") && !cmd.Flags().Changed("monitors") {
+		return fmt.Errorf("at least one of --label, --tags, --managers, or --monitors must be specified")
 	}
 
 	// Create context with timeout

--- a/cmd/flows/start.go
+++ b/cmd/flows/start.go
@@ -18,6 +18,9 @@ var (
 	startInputJSON string
 	startLabel     string
 	startTags      []string
+	startManagers  []string
+	startMonitors  []string
+	startNotify    []string
 	startWait      bool
 )
 
@@ -53,6 +56,9 @@ func init() {
 	StartCmd.Flags().StringVar(&startInputJSON, "input", "", "Input as JSON string")
 	StartCmd.Flags().StringVar(&startLabel, "label", "", "Label for this run")
 	StartCmd.Flags().StringSliceVar(&startTags, "tags", []string{}, "Comma-separated tags")
+	StartCmd.Flags().StringArrayVar(&startManagers, "manager", nil, "A principal that may manage the execution of the run (repeatable)")
+	StartCmd.Flags().StringArrayVar(&startMonitors, "monitor", nil, "A principal that may monitor the execution of the run (repeatable)")
+	StartCmd.Flags().StringSliceVar(&startNotify, "activity-notification-policy", nil, "Comma-separated run statuses that trigger notifications (INACTIVE, SUCCEEDED, FAILED)")
 	StartCmd.Flags().BoolVar(&startWait, "wait", false, "Wait for flow to complete")
 }
 
@@ -106,9 +112,14 @@ func runFlowsStart(cmd *cobra.Command, args []string) error {
 	// Build run input. In v4 the flow ID is passed to RunFlow directly and the
 	// first-state input goes under Body.
 	runInput := &flows.FlowInput{
-		Body:  input,
-		Label: startLabel,
-		Tags:  startTags,
+		Body:        input,
+		Label:       startLabel,
+		Tags:        startTags,
+		RunManagers: startManagers,
+		RunMonitors: startMonitors,
+	}
+	if len(startNotify) > 0 {
+		runInput.ActivityNotificationPolicy = &flows.RunActivityNotificationPolicy{Status: startNotify}
 	}
 
 	// Start the flow (v4 RunFlow replaces the v3 RunFlow(request) form).

--- a/cmd/flows/update.go
+++ b/cmd/flows/update.go
@@ -16,9 +16,19 @@ import (
 var (
 	updateTitle          string
 	updateDescription    string
+	updateSubtitle       string
 	updateDefinitionFile string
 	updateSchemaFile     string
 	updateKeywords       []string
+
+	updateOwner          string
+	updateAdministrators []string
+	updateStarters       []string
+	updateViewers        []string
+	updateRunManagers    []string
+	updateRunMonitors    []string
+	updateSubscriptionID string
+	updateAuthPolicyID   string
 
 	// Authentication policy flags (Python SDK v4.1.0)
 	updateHighAssurance   bool
@@ -57,9 +67,19 @@ Examples:
 func init() {
 	UpdateCmd.Flags().StringVar(&updateTitle, "title", "", "Flow title")
 	UpdateCmd.Flags().StringVar(&updateDescription, "description", "", "Flow description")
+	UpdateCmd.Flags().StringVar(&updateSubtitle, "subtitle", "", "A concise summary of the flow's purpose")
 	UpdateCmd.Flags().StringVar(&updateDefinitionFile, "definition-file", "", "Path to flow definition JSON file")
 	UpdateCmd.Flags().StringVar(&updateSchemaFile, "schema-file", "", "Path to input schema JSON file")
-	UpdateCmd.Flags().StringSliceVar(&updateKeywords, "keywords", []string{}, "Comma-separated keywords")
+	UpdateCmd.Flags().StringSliceVar(&updateKeywords, "keywords", []string{}, "Comma-separated list of keywords (empty string clears)")
+
+	UpdateCmd.Flags().StringVar(&updateOwner, "owner", "", "Assign ownership to your Globus Auth principal ID (you must already be a flow administrator)")
+	UpdateCmd.Flags().StringSliceVar(&updateAdministrators, "administrators", nil, "Comma-separated list of flow administrators (empty string clears)")
+	UpdateCmd.Flags().StringSliceVar(&updateStarters, "starters", nil, "Comma-separated list of flow starters (empty string clears)")
+	UpdateCmd.Flags().StringSliceVar(&updateViewers, "viewers", nil, "Comma-separated list of flow viewers (empty string clears)")
+	UpdateCmd.Flags().StringSliceVar(&updateRunManagers, "run-managers", nil, "Comma-separated list of flow run managers (empty string clears)")
+	UpdateCmd.Flags().StringSliceVar(&updateRunMonitors, "run-monitors", nil, "Comma-separated list of flow run monitors (empty string clears)")
+	UpdateCmd.Flags().StringVar(&updateSubscriptionID, "subscription-id", "", "A subscription ID to assign to the flow (a UUID or \"DEFAULT\")")
+	UpdateCmd.Flags().StringVar(&updateAuthPolicyID, "authentication-policy-id", "", "A Globus Auth authentication policy ID to enforce on the flow (must require high-assurance)")
 
 	// Retained for CLI-surface compatibility; the v4 FlowUpdate model does not
 	// carry a visibility field, so this flag is currently a no-op.
@@ -84,6 +104,36 @@ func runFlowsUpdate(cmd *cobra.Command, args []string) error {
 
 	if updateDescription != "" {
 		request.Description = updateDescription
+	}
+
+	if cmd.Flags().Changed("subtitle") {
+		request.Subtitle = updateSubtitle
+	}
+
+	if cmd.Flags().Changed("owner") {
+		request.FlowOwner = updateOwner
+	}
+
+	if cmd.Flags().Changed("administrators") {
+		request.FlowAdministrators = updateAdministrators
+	}
+	if cmd.Flags().Changed("starters") {
+		request.FlowStarters = updateStarters
+	}
+	if cmd.Flags().Changed("viewers") {
+		request.FlowViewers = updateViewers
+	}
+	if cmd.Flags().Changed("run-managers") {
+		request.RunManagers = updateRunManagers
+	}
+	if cmd.Flags().Changed("run-monitors") {
+		request.RunMonitors = updateRunMonitors
+	}
+	if cmd.Flags().Changed("subscription-id") {
+		request.SubscriptionID = updateSubscriptionID
+	}
+	if cmd.Flags().Changed("authentication-policy-id") {
+		request.AuthenticationPolicyID = updateAuthPolicyID
 	}
 
 	if updateDefinitionFile != "" {

--- a/cmd/group/create.go
+++ b/cmd/group/create.go
@@ -16,6 +16,7 @@ var (
 	createName        string
 	createDescription string
 	createPublic      bool
+	createParentID    string
 )
 
 // CreateCmd represents the group create command
@@ -43,6 +44,7 @@ func init() {
 	CreateCmd.Flags().StringVar(&createName, "name", "", "Name for the new group (required)")
 	CreateCmd.Flags().StringVar(&createDescription, "description", "", "Description of the group")
 	CreateCmd.Flags().BoolVar(&createPublic, "public", false, "Make the group publicly visible")
+	CreateCmd.Flags().StringVar(&createParentID, "parent-id", "", "Make the new group a subgroup of the specified parent group")
 	_ = CreateCmd.MarkFlagRequired("name")
 }
 
@@ -62,6 +64,7 @@ func runCreateGroup(cmd *cobra.Command, args []string) error {
 		Name:        createName,
 		Description: createDescription,
 		PublicGroup: createPublic,
+		ParentID:    createParentID,
 	}
 
 	// Create the group

--- a/cmd/group/join.go
+++ b/cmd/group/join.go
@@ -12,7 +12,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var joinIdentity string
+var (
+	joinIdentity string
+	joinRequest  bool
+)
 
 // JoinCmd represents the group join command
 var JoinCmd = &cobra.Command{
@@ -31,6 +34,7 @@ Examples:
 
 func init() {
 	JoinCmd.Flags().StringVar(&joinIdentity, "identity", "", "Identity ID to join the group as (required)")
+	JoinCmd.Flags().BoolVar(&joinRequest, "request", false, "Create a join request to be approved by a group administrator instead of joining directly")
 	_ = JoinCmd.MarkFlagRequired("identity")
 }
 
@@ -48,16 +52,25 @@ func runJoinGroup(cmd *cobra.Command, args []string) error {
 	}
 
 	// Join the group via a single batch membership action
-	// (POST /groups/{id}); the API has no dedicated join route.
-	_, err = groupsClient.BatchMembershipAction(ctx, groupID, &groups.BatchMembershipActions{
-		Join: []groups.MemberID{{IdentityID: joinIdentity}},
-	})
+	// (POST /groups/{id}); the API has no dedicated join route. With --request,
+	// submit a join request (request_join) instead of joining directly.
+	actions := &groups.BatchMembershipActions{}
+	if joinRequest {
+		actions.RequestJoin = []groups.MemberID{{IdentityID: joinIdentity}}
+	} else {
+		actions.Join = []groups.MemberID{{IdentityID: joinIdentity}}
+	}
+	_, err = groupsClient.BatchMembershipAction(ctx, groupID, actions)
 	if err != nil {
 		return fmt.Errorf("error joining group: %w", err)
 	}
 
 	// Display success message
-	fmt.Fprintf(os.Stdout, "Successfully joined group %s as identity %s.\n", groupID, joinIdentity)
+	if joinRequest {
+		fmt.Fprintf(os.Stdout, "Submitted join request for group %s as identity %s.\n", groupID, joinIdentity)
+	} else {
+		fmt.Fprintf(os.Stdout, "Successfully joined group %s as identity %s.\n", groupID, joinIdentity)
+	}
 
 	return nil
 }

--- a/cmd/group/policies.go
+++ b/cmd/group/policies.go
@@ -105,6 +105,8 @@ var (
 	policiesSetJoinRequests      bool
 	policiesSetVisibility        string
 	policiesSetMembersVisibility string
+	policiesSetSignupFields      []string
+	policiesSetAuthTimeout       int
 )
 
 // policiesSetCmd updates a group's policy settings. It performs a
@@ -134,6 +136,8 @@ Examples:
 	setCmd.Flags().BoolVar(&policiesSetJoinRequests, "join-requests", false, "Allow join requests")
 	setCmd.Flags().StringVar(&policiesSetVisibility, "visibility", "", "Group visibility (authenticated, private)")
 	setCmd.Flags().StringVar(&policiesSetMembersVisibility, "members-visibility", "", "Group members visibility (members, managers)")
+	setCmd.Flags().StringSliceVar(&policiesSetSignupFields, "signup-fields", nil, "Comma-separated list of fields required from users applying for membership (empty string to require none)")
+	setCmd.Flags().IntVar(&policiesSetAuthTimeout, "authentication-timeout", 0, "Time in seconds before a user must re-authenticate to access a high-assurance group")
 
 	return setCmd
 }
@@ -170,6 +174,12 @@ func runPoliciesSet(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("members-visibility") {
 		policies.GroupMembersVisibility = policiesSetMembersVisibility
+	}
+	if cmd.Flags().Changed("signup-fields") {
+		policies.SignupFields = policiesSetSignupFields
+	}
+	if cmd.Flags().Changed("authentication-timeout") {
+		policies.AuthenticationAssuranceTimeout = &policiesSetAuthTimeout
 	}
 
 	if err := groupsClient.SetGroupPolicies(ctx, groupID, policies); err != nil {

--- a/cmd/search/query.go
+++ b/cmd/search/query.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
@@ -15,8 +16,28 @@ import (
 	"github.com/spf13/viper"
 )
 
+// readJSONArg resolves a [JSON_FILE|JSON|file:JSON_FILE] argument (the form the
+// Python CLI accepts for query documents) into raw JSON bytes. A "file:" prefix
+// or an existing path is read from disk; otherwise the value is treated as
+// inline JSON.
+func readJSONArg(arg string) ([]byte, error) {
+	if strings.HasPrefix(arg, "file:") {
+		return os.ReadFile(strings.TrimPrefix(arg, "file:"))
+	}
+	trimmed := strings.TrimSpace(arg)
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return []byte(arg), nil
+	}
+	if data, err := os.ReadFile(arg); err == nil {
+		return data, nil
+	}
+	// Fall back to treating the value as inline JSON.
+	return []byte(arg), nil
+}
+
 var (
 	queryString   string
+	queryDocument string
 	queryLimit    int
 	queryOffset   int
 	queryAdvanced bool
@@ -49,16 +70,19 @@ Examples:
 }
 
 func init() {
-	QueryCmd.Flags().StringVarP(&queryString, "query", "q", "", "Search query string (required)")
+	QueryCmd.Flags().StringVarP(&queryString, "query", "q", "", "Search query string")
+	QueryCmd.Flags().StringVar(&queryDocument, "query-document", "", "A complete query document (inline JSON, a path, or file:PATH). At least one of -q or --query-document is required")
 	QueryCmd.Flags().IntVar(&queryLimit, "limit", 10, "Maximum number of results to return")
 	QueryCmd.Flags().IntVar(&queryOffset, "offset", 0, "Offset for pagination")
 	QueryCmd.Flags().BoolVar(&queryAdvanced, "advanced", false, "Use advanced query syntax")
-
-	_ = QueryCmd.MarkFlagRequired("query")
 }
 
 func runSearchQuery(cmd *cobra.Command, args []string) error {
 	indexID := args[0]
+
+	if queryString == "" && queryDocument == "" {
+		return fmt.Errorf("at least one of -q/--query or --query-document must be provided")
+	}
 
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -70,16 +94,42 @@ func runSearchQuery(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Execute a simple search. Upstream models this as GET
-	// /v1/index/{id}/search with q/offset/limit/advanced query params
-	// (SearchGet), not a POST body — the POST Search sends a malformed body and
-	// returns HTTP 400.
-	response, err := searchClient.SearchGet(ctx, indexID, &search.SearchGetOptions{
-		Q:        queryString,
-		Offset:   queryOffset,
-		Limit:    queryLimit,
-		Advanced: queryAdvanced,
-	})
+	var response *search.SearchResults
+
+	if queryDocument != "" {
+		// A complete query document is posted via POST /index/{id}/search.
+		// Command-line options, when present, override the document's fields.
+		docData, derr := readJSONArg(queryDocument)
+		if derr != nil {
+			return fmt.Errorf("failed to read query document: %w", derr)
+		}
+		var q search.SearchQuery
+		if uerr := json.Unmarshal(docData, &q); uerr != nil {
+			return fmt.Errorf("failed to parse query document JSON: %w", uerr)
+		}
+		if cmd.Flags().Changed("query") {
+			q.Q = queryString
+		}
+		if cmd.Flags().Changed("limit") {
+			q.Limit = queryLimit
+		}
+		if cmd.Flags().Changed("offset") {
+			q.Offset = queryOffset
+		}
+		if cmd.Flags().Changed("advanced") {
+			q.AdvancedQuery = queryAdvanced
+		}
+		response, err = searchClient.Search(ctx, indexID, &q)
+	} else {
+		// A simple query string is modeled as GET /v1/index/{id}/search with
+		// q/offset/limit/advanced query params (SearchGet).
+		response, err = searchClient.SearchGet(ctx, indexID, &search.SearchGetOptions{
+			Q:        queryString,
+			Offset:   queryOffset,
+			Limit:    queryLimit,
+			Advanced: queryAdvanced,
+		})
+	}
 	if err != nil {
 		return fmt.Errorf("error executing search: %w", err)
 	}

--- a/cmd/timer/create_flow.go
+++ b/cmd/timer/create_flow.go
@@ -14,15 +14,16 @@ import (
 )
 
 var (
-	createFlowName      string
-	createFlowInterval  string
-	createFlowCron      string
-	createFlowInput     string
-	createFlowScope     string
-	createFlowLabel     string
-	createFlowStart     string
-	createFlowStop      string
-	createFlowTimezone  string
+	createFlowName     string
+	createFlowInterval string
+	createFlowCron     string
+	createFlowInput    string
+	createFlowScope    string
+	createFlowLabel    string
+	createFlowStart    string
+	createFlowStop     string
+	createFlowStopRuns int
+	createFlowTimezone string
 )
 
 // CreateFlowCmd represents the timer create flow command
@@ -81,6 +82,7 @@ func init() {
 	CreateFlowCmd.Flags().StringVar(&createFlowLabel, "flow-label", "", "Label for the flow run")
 	CreateFlowCmd.Flags().StringVar(&createFlowStart, "start", "", "Start time (RFC3339 format, required)")
 	CreateFlowCmd.Flags().StringVar(&createFlowStop, "stop", "", "Stop time (RFC3339 format)")
+	CreateFlowCmd.Flags().IntVar(&createFlowStopRuns, "stop-after-runs", 0, "Stop running the flow after this number of runs")
 	CreateFlowCmd.Flags().StringVar(&createFlowTimezone, "timezone", "UTC", "Deprecated: only used with the removed cron scheduling")
 
 	_ = CreateFlowCmd.MarkFlagRequired("name")
@@ -149,8 +151,13 @@ func runCreateFlowTimer(cmd *cobra.Command, args []string) error {
 		if derr != nil || d <= 0 {
 			return fmt.Errorf("invalid --interval %q: use a Go duration such as 1h, 30m, or 24h", createFlowInterval)
 		}
+		if stopTime != nil && createFlowStopRuns > 0 {
+			return fmt.Errorf("--stop and --stop-after-runs are mutually exclusive")
+		}
 		var end *timers.ScheduleEnd
-		if stopTime != nil {
+		if createFlowStopRuns > 0 {
+			end = &timers.ScheduleEnd{Condition: "iterations", Iterations: createFlowStopRuns}
+		} else if stopTime != nil {
 			end = &timers.ScheduleEnd{Condition: "time", Datetime: stopTime.Format(time.RFC3339)}
 		}
 		schedule = timers.NewRecurringSchedule(int(d.Seconds()), startTime.Format(time.RFC3339), end)

--- a/cmd/timer/create_transfer.go
+++ b/cmd/timer/create_transfer.go
@@ -40,6 +40,7 @@ var (
 	createTransferInterval          string
 	createTransferStart             string
 	createTransferStop              string
+	createTransferLabel             string
 	createTransferInclude           []string
 	createTransferExclude           []string
 )
@@ -100,6 +101,7 @@ func init() {
 	CreateTransferCmd.Flags().BoolVar(&createTransferEncryptData, "encrypt-data", false, "Encrypt data during transfer")
 	CreateTransferCmd.Flags().BoolVar(&createTransferDelete, "delete", false, "Delete extra files at destination (directory mirroring)")
 	CreateTransferCmd.Flags().StringVar(&createTransferDeadline, "deadline", "", "Task deadline (RFC3339 format)")
+	CreateTransferCmd.Flags().StringVar(&createTransferLabel, "label", "", "A label for the Transfer tasks submitted by the timer")
 	CreateTransferCmd.Flags().StringArrayVar(&createTransferInclude, "include", []string{}, "Include patterns")
 	CreateTransferCmd.Flags().StringArrayVar(&createTransferExclude, "exclude", []string{}, "Exclude patterns")
 
@@ -143,20 +145,25 @@ func runCreateTransferTimer(cmd *cobra.Command, args []string) error {
 	}
 
 	transferBody := map[string]interface{}{
-		"DATA_TYPE":             "transfer",
-		"source_endpoint":       sourceEndpoint,
-		"destination_endpoint":  destEndpoint,
-		"DATA":                  []interface{}{transferItem},
-		"sync_level":            createTransferSyncLevel,
-		"verify_checksum":       createTransferVerifyChecksum,
-		"preserve_timestamp":    createTransferPreserveTimestamp,
-		"encrypt_data":          createTransferEncryptData,
+		"DATA_TYPE":                "transfer",
+		"source_endpoint":          sourceEndpoint,
+		"destination_endpoint":     destEndpoint,
+		"DATA":                     []interface{}{transferItem},
+		"sync_level":               createTransferSyncLevel,
+		"verify_checksum":          createTransferVerifyChecksum,
+		"preserve_timestamp":       createTransferPreserveTimestamp,
+		"encrypt_data":             createTransferEncryptData,
 		"delete_destination_extra": createTransferDelete,
 	}
 
 	// Add deadline if specified
 	if createTransferDeadline != "" {
 		transferBody["deadline"] = createTransferDeadline
+	}
+
+	// Add label if specified
+	if createTransferLabel != "" {
+		transferBody["label"] = createTransferLabel
 	}
 
 	// Add filter rules if specified
@@ -203,10 +210,10 @@ func runCreateTransferTimer(cmd *cobra.Command, args []string) error {
 
 	// Build v2 transfer timer request
 	timerRequest := map[string]interface{}{
-		"name":     createTransferName,
+		"name":       createTransferName,
 		"timer_type": "transfer",
-		"schedule": schedule,
-		"body":     transferBody,
+		"schedule":   schedule,
+		"body":       transferBody,
 	}
 
 	// Marshal request to JSON

--- a/cmd/transfer/cp.go
+++ b/cmd/transfer/cp.go
@@ -16,14 +16,27 @@ import (
 )
 
 var (
-	transferRecursive    bool
-	transferSync         int
-	transferPreserveTime bool
-	transferVerify       bool
-	transferLabel        string
-	transferWait         bool
-	transferDryRun       bool
-	transferDeadline     string
+	transferRecursive        bool
+	transferSync             int
+	transferSyncLevel        string
+	transferPreserveTime     bool
+	transferVerify           bool
+	transferEncrypt          bool
+	transferLabel            string
+	transferWait             bool
+	transferDryRun           bool
+	transferDeadline         string
+	transferSubmissionID     string
+	transferNotify           []string
+	transferSkipSourceErrors bool
+	transferFailOnQuota      bool
+	transferDeleteDestExtra  bool
+	transferInclude          []string
+	transferExclude          []string
+	transferExternalChecksum string
+	transferChecksumAlgo     string
+	transferSourceLocalUser  string
+	transferDestLocalUser    string
 )
 
 // CpCmd returns the cp command
@@ -54,10 +67,23 @@ Examples:
 
 	// Add flags
 	cmd.Flags().BoolVarP(&transferRecursive, "recursive", "r", false, "Transfer directories recursively")
-	cmd.Flags().IntVar(&transferSync, "sync-level", 0, "Synchronization level (0-3)")
-	cmd.Flags().BoolVar(&transferPreserveTime, "preserve-timestamp", false, "Preserve file timestamps")
-	cmd.Flags().BoolVar(&transferVerify, "verify", false, "Verify file integrity after transfer")
+	cmd.Flags().StringVarP(&transferSyncLevel, "sync-level", "s", "", "Sync level: exists, size, mtime, checksum (or 0-3)")
+	cmd.Flags().BoolVar(&transferPreserveTime, "preserve-timestamp", false, "Preserve file modification times")
+	cmd.Flags().BoolVar(&transferPreserveTime, "preserve-mtime", false, "Preserve file modification times (alias of --preserve-timestamp)")
+	cmd.Flags().BoolVar(&transferVerify, "verify-checksum", true, "Verify checksum after transfer")
+	cmd.Flags().BoolVar(&transferEncrypt, "encrypt-data", false, "Encrypt data sent through the network")
 	cmd.Flags().StringVar(&transferLabel, "label", "", "Label for the transfer task")
+	cmd.Flags().StringVar(&transferSubmissionID, "submission-id", "", "Task submission ID for safe resubmission")
+	cmd.Flags().StringSliceVar(&transferNotify, "notify", nil, "Comma-separated task events that notify by email (on, off, succeeded, failed, inactive)")
+	cmd.Flags().BoolVar(&transferSkipSourceErrors, "skip-source-errors", false, "Skip source paths that hit permission-denied or not-found errors")
+	cmd.Flags().BoolVar(&transferFailOnQuota, "fail-on-quota-errors", false, "Fail the task if any quota-exceeded errors are hit")
+	cmd.Flags().BoolVar(&transferDeleteDestExtra, "delete-destination-extra", false, "Delete files in the destination not in the source (recursive mirroring)")
+	cmd.Flags().StringArrayVar(&transferInclude, "include", nil, "Include files matching the given glob pattern in recursive transfers (repeatable)")
+	cmd.Flags().StringArrayVar(&transferExclude, "exclude", nil, "Exclude files matching the given glob pattern in recursive transfers (repeatable)")
+	cmd.Flags().StringVar(&transferExternalChecksum, "external-checksum", "", "External checksum to verify source file integrity")
+	cmd.Flags().StringVar(&transferChecksumAlgo, "checksum-algorithm", "", "Algorithm for --external-checksum or --verify-checksum")
+	cmd.Flags().StringVar(&transferSourceLocalUser, "source-local-user", "", "Local user to map to on the source (GCSv5 mapped collections)")
+	cmd.Flags().StringVar(&transferDestLocalUser, "destination-local-user", "", "Local user to map to on the destination (GCSv5 mapped collections)")
 	cmd.Flags().BoolVar(&transferWait, "wait", false, "Wait for the transfer to complete")
 	cmd.Flags().BoolVar(&transferDryRun, "dry-run", false, "Don't actually perform the transfer (test only)")
 	cmd.Flags().StringVar(&transferDeadline, "deadline", "", "Transfer deadline (YYYY-MM-DD)")
@@ -86,6 +112,23 @@ func transferFiles(cmd *cobra.Command, sourceEndpointID, sourcePath, destEndpoin
 		deadline = transferDeadline
 	}
 
+	// Resolve sync level. Python accepts named levels (exists/size/mtime/checksum);
+	// we also accept the raw ints 0-3 for backward compatibility. Unset leaves the
+	// SDK default (0, omitted).
+	if cmd.Flags().Changed("sync-level") {
+		lvl, err := parseSyncLevel(transferSyncLevel)
+		if err != nil {
+			return err
+		}
+		transferSync = lvl
+	}
+
+	// Resolve notify events into the boolean notify_on_* fields.
+	notifySucceeded, notifyFailed, notifyInactive, err := parseNotify(transferNotify)
+	if err != nil {
+		return err
+	}
+
 	// Show transfer details and confirm if not in dry run mode
 	if !transferDryRun {
 		fmt.Println("Transfer Details:")
@@ -112,29 +155,44 @@ func transferFiles(cmd *cobra.Command, sourceEndpointID, sourcePath, destEndpoin
 	s.Start()
 
 	// Build the v4 transfer request. A submission ID minted from the service is
-	// required for idempotent submission.
-	submissionID, err := transferClient.GetSubmissionID(ctx)
-	if err != nil {
-		s.Stop()
-		return fmt.Errorf("failed to get submission ID: %w", err)
+	// required for idempotent submission; honor an explicitly supplied one.
+	submissionID := transferSubmissionID
+	if submissionID == "" {
+		submissionID, err = transferClient.GetSubmissionID(ctx)
+		if err != nil {
+			s.Stop()
+			return fmt.Errorf("failed to get submission ID: %w", err)
+		}
 	}
 
 	request := &transfer.Transfer{
-		DATA_TYPE:           "transfer",
-		SubmissionID:        submissionID,
-		SourceEndpoint:      sourceEndpointID,
-		DestinationEndpoint: destEndpointID,
-		Label:               transferLabel,
-		SyncLevel:           transferSync,
-		VerifyChecksum:      transferVerify,
-		PreserveTimestamp:   transferPreserveTime,
-		Deadline:            deadline,
+		DATA_TYPE:              "transfer",
+		SubmissionID:           submissionID,
+		SourceEndpoint:         sourceEndpointID,
+		DestinationEndpoint:    destEndpointID,
+		Label:                  transferLabel,
+		SyncLevel:              transferSync,
+		VerifyChecksum:         transferVerify,
+		PreserveTimestamp:      transferPreserveTime,
+		EncryptData:            transferEncrypt,
+		DeleteDestinationExtra: transferDeleteDestExtra,
+		SkipSourceErrors:       transferSkipSourceErrors,
+		FailOnQuotaErrors:      transferFailOnQuota,
+		SourceLocalUser:        transferSourceLocalUser,
+		DestinationLocalUser:   transferDestLocalUser,
+		NotifyOnSucceeded:      notifySucceeded,
+		NotifyOnFailed:         notifyFailed,
+		NotifyOnInactive:       notifyInactive,
+		Deadline:               deadline,
+		FilterRules:            buildFilterRules(transferInclude, transferExclude),
 		Items: []transfer.TransferItem{
 			{
-				DATA_TYPE:       "transfer_item",
-				SourcePath:      sourcePath,
-				DestinationPath: destPath,
-				Recursive:       transferRecursive,
+				DATA_TYPE:         "transfer_item",
+				SourcePath:        sourcePath,
+				DestinationPath:   destPath,
+				Recursive:         transferRecursive,
+				ExternalChecksum:  transferExternalChecksum,
+				ChecksumAlgorithm: transferChecksumAlgo,
 			},
 		},
 	}
@@ -158,4 +216,72 @@ func transferFiles(cmd *cobra.Command, sourceEndpointID, sourcePath, destEndpoin
 	}
 
 	return nil
+}
+
+// parseSyncLevel maps Python's named sync levels to the integer the Transfer
+// API expects, while still accepting the raw integers 0-3 for compatibility.
+func parseSyncLevel(v string) (int, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "exists", "0":
+		return 0, nil
+	case "size", "1":
+		return 1, nil
+	case "mtime", "2":
+		return 2, nil
+	case "checksum", "3":
+		return 3, nil
+	default:
+		return 0, fmt.Errorf("invalid sync level %q (use exists, size, mtime, checksum, or 0-3)", v)
+	}
+}
+
+// parseNotify converts Python's comma-separated --notify events into the
+// notify_on_* booleans. "on" enables all, "off" disables all.
+func parseNotify(events []string) (succeeded, failed, inactive bool, err error) {
+	if len(events) == 0 {
+		// Default: notify on succeeded and failed (Transfer API default).
+		return true, true, true, nil
+	}
+	for _, e := range events {
+		switch strings.ToLower(strings.TrimSpace(e)) {
+		case "on":
+			succeeded, failed, inactive = true, true, true
+		case "off":
+			succeeded, failed, inactive = false, false, false
+		case "succeeded":
+			succeeded = true
+		case "failed":
+			failed = true
+		case "inactive":
+			inactive = true
+		case "":
+			// ignore empty tokens
+		default:
+			return false, false, false, fmt.Errorf("invalid --notify value %q (use on, off, succeeded, failed, inactive)", e)
+		}
+	}
+	return succeeded, failed, inactive, nil
+}
+
+// buildFilterRules converts --include/--exclude glob patterns into the Transfer
+// API filter_rules list. Includes are emitted before excludes; the common
+// idiom `--include "*.txt" --exclude "*"` therefore behaves as expected. Note:
+// because cobra collects the two flags into separate slices, the exact
+// interleaving of includes and excludes on the command line is not preserved.
+func buildFilterRules(include, exclude []string) []transfer.FilterRule {
+	if len(include) == 0 && len(exclude) == 0 {
+		return nil
+	}
+	rules := make([]transfer.FilterRule, 0, len(include)+len(exclude))
+	for _, p := range include {
+		rules = append(rules, transfer.FilterRule{
+			DATA_TYPE: "filter_rule", Method: "include", Name: p, Type: "file",
+		})
+	}
+	for _, p := range exclude {
+		rules = append(rules, transfer.FilterRule{
+			DATA_TYPE: "filter_rule", Method: "exclude", Name: p, Type: "file",
+		})
+	}
+	return rules
 }

--- a/cmd/transfer/delete.go
+++ b/cmd/transfer/delete.go
@@ -15,6 +15,11 @@ import (
 var (
 	deleteRecursive     bool
 	deleteIgnoreMissing bool
+	deleteLabel         string
+	deleteDeadline      string
+	deleteLocalUser     string
+	deleteEnableGlobs   bool
+	deleteNotify        []string
 )
 
 // DeleteCmd returns the delete command
@@ -45,8 +50,13 @@ Examples:
 	}
 
 	// Add flags
-	cmd.Flags().BoolVar(&deleteRecursive, "recursive", false, "Delete directories and their contents recursively")
-	cmd.Flags().BoolVar(&deleteIgnoreMissing, "ignore-missing", false, "Do not error if the path does not exist")
+	cmd.Flags().BoolVarP(&deleteRecursive, "recursive", "r", false, "Delete directories and their contents recursively")
+	cmd.Flags().BoolVarP(&deleteIgnoreMissing, "ignore-missing", "f", false, "Do not error if the path does not exist")
+	cmd.Flags().StringVar(&deleteLabel, "label", "", "Set a label for this task")
+	cmd.Flags().StringVar(&deleteDeadline, "deadline", "", "Deadline for the task (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&deleteLocalUser, "local-user", "", "Local user to map to (GCSv5 mapped collections)")
+	cmd.Flags().BoolVar(&deleteEnableGlobs, "enable-globs", false, "Interpret shell-style globs in paths")
+	cmd.Flags().StringSliceVar(&deleteNotify, "notify", nil, "Notification settings: any of on, off, succeeded, failed, inactive")
 
 	return cmd
 }
@@ -70,12 +80,29 @@ func submitDeleteTask(cmd *cobra.Command, endpointID, path string) error {
 		return fmt.Errorf("failed to get submission ID: %w", err)
 	}
 
+	if deleteDeadline != "" {
+		if _, err := time.Parse("2006-01-02", deleteDeadline); err != nil {
+			return fmt.Errorf("invalid deadline format, use YYYY-MM-DD: %w", err)
+		}
+	}
+	notifySucceeded, notifyFailed, notifyInactive, err := parseNotify(deleteNotify)
+	if err != nil {
+		return err
+	}
+
 	deleteRequest := &transfer.Delete{
-		DATA_TYPE:     "delete",
-		SubmissionID:  submissionID,
-		Endpoint:      endpointID,
-		Recursive:     deleteRecursive,
-		IgnoreMissing: deleteIgnoreMissing,
+		DATA_TYPE:         "delete",
+		SubmissionID:      submissionID,
+		Endpoint:          endpointID,
+		Label:             deleteLabel,
+		Recursive:         deleteRecursive,
+		IgnoreMissing:     deleteIgnoreMissing,
+		InterpretGlob:     deleteEnableGlobs,
+		LocalUser:         deleteLocalUser,
+		Deadline:          deleteDeadline,
+		NotifyOnSucceeded: notifySucceeded,
+		NotifyOnFailed:    notifyFailed,
+		NotifyOnInactive:  notifyInactive,
 		Items: []transfer.DeleteItem{
 			{DATA_TYPE: "delete_item", Path: path},
 		},

--- a/cmd/transfer/endpoint.go
+++ b/cmd/transfer/endpoint.go
@@ -51,6 +51,10 @@ var (
 	filterMyTasksOnly  bool
 	searchText         string
 	limit              int
+
+	// Endpoint search-specific filters (globus endpoint search).
+	searchFilterScope      string
+	searchFilterEntityType string
 )
 
 // endpointListCmd returns the endpoint list command
@@ -114,6 +118,9 @@ returning matches based on the provided search text.`,
 	}
 
 	// Add flags for filtering
+	cmd.Flags().StringVar(&searchFilterScope, "filter-scope", "all", "The set of endpoints to search over (all, administered-by-me, my-endpoints, my-gcp-endpoints, recently-used, in-use, shared-by-me, shared-with-me)")
+	cmd.Flags().StringVar(&filterOwner, "filter-owner-id", "", "Filter results to endpoints owned by a specific identity (ID or username)")
+	cmd.Flags().StringVar(&searchFilterEntityType, "filter-entity-type", "", "Filter results to a specific entity type (gcp_mapped_collection, gcp_guest_collection, gcsv5_endpoint, gcsv5_mapped_collection, gcsv5_guest_collection)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Maximum number of endpoints to return")
 
 	return cmd
@@ -145,6 +152,15 @@ func listEndpoints(cmd *cobra.Command) error {
 		options.FilterScope = "recently-used"
 	} else if filterMyTasksOnly {
 		options.FilterScope = "in-use"
+	}
+
+	// endpoint search: --filter-scope (default "all" means no server filter) and
+	// --filter-entity-type. These flags are only registered on the search command.
+	if searchFilterScope != "" && searchFilterScope != "all" {
+		options.FilterScope = searchFilterScope
+	}
+	if searchFilterEntityType != "" {
+		options.FilterEntityType = searchFilterEntityType
 	}
 
 	// Search text for full text search.

--- a/cmd/transfer/endpoint_admin.go
+++ b/cmd/transfer/endpoint_admin.go
@@ -17,12 +17,36 @@ import (
 // endpoint document with only the fields the user explicitly set.
 func endpointUpdateCmd() *cobra.Command {
 	var (
-		displayName  string
-		description  string
-		organization string
-		contactEmail string
-		keywords     []string
-		public       bool
+		displayName          string
+		description          string
+		organization         string
+		department           string
+		contactEmail         string
+		contactInfo          string
+		infoLink             string
+		defaultDirectory     string
+		noDefaultDirectory   bool
+		keywords             []string
+		public               bool
+		private              bool
+		forceEncryption      bool
+		noForceEncryption    bool
+		disableVerify        bool
+		noDisableVerify      bool
+		subscriptionID       string
+		noManaged            bool
+		managed              bool
+		networkUse           string
+		maxConcurrency       int
+		preferredConcurrency int
+		maxParallelism       int
+		preferredParallelism int
+		userMessage          string
+		userMessageLink      string
+		oauthServer          string
+		myproxyServer        string
+		myproxyDN            string
+		location             string
 	)
 
 	cmd := &cobra.Command{
@@ -51,14 +75,90 @@ Only the flags you provide are sent; unset fields are left unchanged.`,
 			if cmd.Flags().Changed("organization") {
 				doc["organization"] = organization
 			}
+			if cmd.Flags().Changed("department") {
+				doc["department"] = department
+			}
 			if cmd.Flags().Changed("contact-email") {
 				doc["contact_email"] = contactEmail
+			}
+			if cmd.Flags().Changed("contact-info") {
+				doc["contact_info"] = contactInfo
+			}
+			if cmd.Flags().Changed("info-link") {
+				doc["info_link"] = infoLink
+			}
+			if cmd.Flags().Changed("default-directory") {
+				doc["default_directory"] = defaultDirectory
+			}
+			if noDefaultDirectory {
+				doc["default_directory"] = nil
 			}
 			if cmd.Flags().Changed("keywords") {
 				doc["keywords"] = keywords
 			}
+			// --public / --private
 			if cmd.Flags().Changed("public") {
 				doc["public"] = public
+			}
+			if private {
+				doc["public"] = false
+			}
+			// --force-encryption / --no-force-encryption
+			if cmd.Flags().Changed("force-encryption") {
+				doc["force_encryption"] = forceEncryption
+			}
+			if noForceEncryption {
+				doc["force_encryption"] = false
+			}
+			// --disable-verify / --no-disable-verify
+			if cmd.Flags().Changed("disable-verify") {
+				doc["disable_verify"] = disableVerify
+			}
+			if noDisableVerify {
+				doc["disable_verify"] = false
+			}
+			// Managed-endpoint / subscription handling.
+			if cmd.Flags().Changed("subscription-id") {
+				doc["subscription_id"] = subscriptionID
+			}
+			if noManaged {
+				doc["subscription_id"] = nil
+			}
+			if managed {
+				return fmt.Errorf("--managed is not supported: it requires resolving your subscription ID; use --subscription-id instead")
+			}
+			if cmd.Flags().Changed("network-use") {
+				doc["network_use"] = networkUse
+			}
+			if cmd.Flags().Changed("max-concurrency") {
+				doc["max_concurrency"] = maxConcurrency
+			}
+			if cmd.Flags().Changed("preferred-concurrency") {
+				doc["preferred_concurrency"] = preferredConcurrency
+			}
+			if cmd.Flags().Changed("max-parallelism") {
+				doc["max_parallelism"] = maxParallelism
+			}
+			if cmd.Flags().Changed("preferred-parallelism") {
+				doc["preferred_parallelism"] = preferredParallelism
+			}
+			if cmd.Flags().Changed("user-message") {
+				doc["user_message"] = userMessage
+			}
+			if cmd.Flags().Changed("user-message-link") {
+				doc["user_message_link"] = userMessageLink
+			}
+			if cmd.Flags().Changed("oauth-server") {
+				doc["oauth_server"] = oauthServer
+			}
+			if cmd.Flags().Changed("myproxy-server") {
+				doc["myproxy_server"] = myproxyServer
+			}
+			if cmd.Flags().Changed("myproxy-dn") {
+				doc["myproxy_dn"] = myproxyDN
+			}
+			if cmd.Flags().Changed("location") {
+				doc["location"] = location
 			}
 
 			resp, err := client.UpdateEndpoint(ctx, args[0], doc)
@@ -72,12 +172,36 @@ Only the flags you provide are sent; unset fields are left unchanged.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&displayName, "display-name", "", "New display name")
-	cmd.Flags().StringVar(&description, "description", "", "New description")
-	cmd.Flags().StringVar(&organization, "organization", "", "New organization")
-	cmd.Flags().StringVar(&contactEmail, "contact-email", "", "New contact email")
-	cmd.Flags().StringSliceVar(&keywords, "keywords", nil, "Keywords for the endpoint")
-	cmd.Flags().BoolVar(&public, "public", false, "Whether the endpoint is public")
+	cmd.Flags().StringVar(&displayName, "display-name", "", "Name for the endpoint")
+	cmd.Flags().StringVar(&description, "description", "", "Description for the endpoint")
+	cmd.Flags().StringVar(&organization, "organization", "", "Organization for the endpoint")
+	cmd.Flags().StringVar(&department, "department", "", "Department which operates the endpoint")
+	cmd.Flags().StringVar(&contactEmail, "contact-email", "", "Contact email for the endpoint")
+	cmd.Flags().StringVar(&contactInfo, "contact-info", "", "Contact info for the endpoint")
+	cmd.Flags().StringVar(&infoLink, "info-link", "", "Link for info about the endpoint")
+	cmd.Flags().StringVar(&defaultDirectory, "default-directory", "", "Default directory when browsing or executing tasks on the endpoint")
+	cmd.Flags().BoolVar(&noDefaultDirectory, "no-default-directory", false, "Unset any default directory on the endpoint")
+	cmd.Flags().StringSliceVar(&keywords, "keywords", nil, "Comma separated list of keywords to help searches for the endpoint")
+	cmd.Flags().BoolVar(&public, "public", false, "Set the endpoint to be public")
+	cmd.Flags().BoolVar(&private, "private", false, "Set the endpoint to be private")
+	cmd.Flags().BoolVar(&forceEncryption, "force-encryption", false, "Force the endpoint to encrypt transfers")
+	cmd.Flags().BoolVar(&noForceEncryption, "no-force-encryption", false, "Do not force the endpoint to encrypt transfers")
+	cmd.Flags().BoolVar(&disableVerify, "disable-verify", false, "Set the endpoint to ignore checksum verification")
+	cmd.Flags().BoolVar(&noDisableVerify, "no-disable-verify", false, "Do not ignore checksum verification")
+	cmd.Flags().StringVar(&subscriptionID, "subscription-id", "", "Set the endpoint as managed with the given subscription ID")
+	cmd.Flags().BoolVar(&noManaged, "no-managed", false, "Unset the endpoint as a managed endpoint")
+	cmd.Flags().BoolVar(&managed, "managed", false, "Set the endpoint as a managed endpoint (requires --subscription-id)")
+	cmd.Flags().StringVar(&networkUse, "network-use", "", "Network use level (normal, minimal, aggressive, custom)")
+	cmd.Flags().IntVar(&maxConcurrency, "max-concurrency", 0, "Endpoint max concurrency; requires --network-use=custom")
+	cmd.Flags().IntVar(&preferredConcurrency, "preferred-concurrency", 0, "Endpoint preferred concurrency; requires --network-use=custom")
+	cmd.Flags().IntVar(&maxParallelism, "max-parallelism", 0, "Endpoint max parallelism; requires --network-use=custom")
+	cmd.Flags().IntVar(&preferredParallelism, "preferred-parallelism", 0, "Endpoint preferred parallelism; requires --network-use=custom")
+	cmd.Flags().StringVar(&userMessage, "user-message", "", "A message for clients to display to users when interacting with this endpoint")
+	cmd.Flags().StringVar(&userMessageLink, "user-message-link", "", "Link to additional messaging for clients to display to users")
+	cmd.Flags().StringVar(&oauthServer, "oauth-server", "", "Set the OAuth Server URI (Globus Connect Server only)")
+	cmd.Flags().StringVar(&myproxyServer, "myproxy-server", "", "Set the MyProxy Server URI (Globus Connect Server only)")
+	cmd.Flags().StringVar(&myproxyDN, "myproxy-dn", "", "Set the MyProxy Server DN (Globus Connect Server only)")
+	cmd.Flags().StringVar(&location, "location", "", "Manually set the endpoint's LATITUDE,LONGITUDE (Globus Connect Server only)")
 
 	return cmd
 }
@@ -180,6 +304,8 @@ func endpointRoleCreateCmd() *cobra.Command {
 		principal     string
 		principalType string
 		role          string
+		identity      string
+		group         string
 	)
 
 	cmd := &cobra.Command{
@@ -188,7 +314,10 @@ func endpointRoleCreateCmd() *cobra.Command {
 		Long: `Assign a role to a principal on a Globus endpoint.
 
 The --role value is one of administrator, access_manager, activity_manager,
-or activity_monitor.`,
+or activity_monitor.
+
+Specify the security principal with exactly one of --identity, --group, or the
+lower-level --principal/--principal-type pair.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -197,6 +326,19 @@ or activity_monitor.`,
 			client, err := getClient(ctx)
 			if err != nil {
 				return err
+			}
+
+			// Resolve the principal from --identity/--group (Python-compatible)
+			// or the explicit --principal/--principal-type pair.
+			if identity != "" {
+				principal = identity
+				principalType = "identity"
+			} else if group != "" {
+				principal = group
+				principalType = "group"
+			}
+			if principal == "" {
+				return fmt.Errorf("one of --identity, --group, or --principal is required")
 			}
 
 			doc := map[string]interface{}{
@@ -214,10 +356,11 @@ or activity_monitor.`,
 		},
 	}
 
+	cmd.Flags().StringVar(&identity, "identity", "", "Identity ID to use as the security principal")
+	cmd.Flags().StringVar(&group, "group", "", "Group ID to use as the security principal")
 	cmd.Flags().StringVar(&principal, "principal", "", "Principal (identity or group ID) to assign the role to")
 	cmd.Flags().StringVar(&principalType, "principal-type", "identity", "Principal type (identity or group)")
 	cmd.Flags().StringVar(&role, "role", "", "Role name (administrator, access_manager, activity_manager, activity_monitor)")
-	_ = cmd.MarkFlagRequired("principal")
 	_ = cmd.MarkFlagRequired("role")
 
 	return cmd
@@ -317,10 +460,17 @@ func endpointPermissionShowCmd() *cobra.Command {
 
 func endpointPermissionCreateCmd() *cobra.Command {
 	var (
-		permissions   string
-		principal     string
-		principalType string
-		path          string
+		permissions      string
+		principal        string
+		principalType    string
+		path             string
+		identity         string
+		group            string
+		allAuthenticated bool
+		anonymous        bool
+		notifyEmail      string
+		notifyMessage    string
+		expirationDate   string
 	)
 
 	cmd := &cobra.Command{
@@ -328,7 +478,9 @@ func endpointPermissionCreateCmd() *cobra.Command {
 		Short: "Create an access rule on an endpoint",
 		Long: `Create an access rule (ACL) granting permissions on a path.
 
-The --principal-type value is one of identity, group,
+Specify the security principal with exactly one of --identity, --group,
+--all-authenticated, --anonymous, or the lower-level --principal/--principal-type
+pair. The --principal-type value is one of identity, group,
 all_authenticated_users, or anonymous.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -340,12 +492,38 @@ all_authenticated_users, or anonymous.`,
 				return err
 			}
 
+			// Resolve the principal from the Python-compatible convenience flags
+			// or the explicit --principal/--principal-type pair.
+			switch {
+			case identity != "":
+				principal = identity
+				principalType = "identity"
+			case group != "":
+				principal = group
+				principalType = "group"
+			case allAuthenticated:
+				principal = ""
+				principalType = "all_authenticated_users"
+			case anonymous:
+				principal = ""
+				principalType = "anonymous"
+			}
+
 			doc := map[string]interface{}{
 				"DATA_TYPE":      "access",
 				"principal_type": principalType,
 				"principal":      principal,
 				"path":           path,
 				"permissions":    permissions,
+			}
+			if cmd.Flags().Changed("notify-email") {
+				doc["notify_email"] = notifyEmail
+			}
+			if cmd.Flags().Changed("notify-message") {
+				doc["notify_message"] = notifyMessage
+			}
+			if cmd.Flags().Changed("expiration-date") {
+				doc["expiration_date"] = expirationDate
 			}
 
 			resp, err := client.AddEndpointACLRule(ctx, args[0], doc)
@@ -356,10 +534,17 @@ all_authenticated_users, or anonymous.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&permissions, "permissions", "", `Permissions to grant (e.g. "r" or "rw")`)
+	cmd.Flags().StringVar(&permissions, "permissions", "", `Permissions to add: "r" (Read-Only) or "rw" (Read/Write)`)
+	cmd.Flags().StringVar(&identity, "identity", "", "Identity ID to use as the security principal")
+	cmd.Flags().StringVar(&group, "group", "", "Group ID to use as the security principal")
+	cmd.Flags().BoolVar(&allAuthenticated, "all-authenticated", false, "Allow anyone access, as long as they log in")
+	cmd.Flags().BoolVar(&anonymous, "anonymous", false, "Allow anyone access, even without logging in")
 	cmd.Flags().StringVar(&principal, "principal", "", "Principal (identity or group ID) to grant access to")
 	cmd.Flags().StringVar(&principalType, "principal-type", "identity", "Principal type (identity, group, all_authenticated_users, anonymous)")
 	cmd.Flags().StringVar(&path, "path", "", "Path the rule applies to")
+	cmd.Flags().StringVar(&notifyEmail, "notify-email", "", "An email address to notify that the permission has been added")
+	cmd.Flags().StringVar(&notifyMessage, "notify-message", "", "A custom message to add to email notifications")
+	cmd.Flags().StringVar(&expirationDate, "expiration-date", "", "Expiration date for the permission in ISO 8601 format")
 	_ = cmd.MarkFlagRequired("permissions")
 	_ = cmd.MarkFlagRequired("path")
 
@@ -367,7 +552,10 @@ all_authenticated_users, or anonymous.`,
 }
 
 func endpointPermissionUpdateCmd() *cobra.Command {
-	var permissions string
+	var (
+		permissions    string
+		expirationDate string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "update ENDPOINT_ID RULE_ID",
@@ -386,6 +574,9 @@ func endpointPermissionUpdateCmd() *cobra.Command {
 				"DATA_TYPE":   "access",
 				"permissions": permissions,
 			}
+			if cmd.Flags().Changed("expiration-date") {
+				doc["expiration_date"] = expirationDate
+			}
 
 			resp, err := client.UpdateEndpointACLRule(ctx, args[0], args[1], doc)
 			if err != nil {
@@ -395,7 +586,8 @@ func endpointPermissionUpdateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&permissions, "permissions", "", `New permissions (e.g. "r" or "rw")`)
+	cmd.Flags().StringVar(&permissions, "permissions", "", `Permissions to add: "r" (Read-Only) or "rw" (Read/Write)`)
+	cmd.Flags().StringVar(&expirationDate, "expiration-date", "", "Expiration date for the permission in ISO 8601 format")
 	_ = cmd.MarkFlagRequired("permissions")
 
 	return cmd

--- a/cmd/transfer/ls.go
+++ b/cmd/transfer/ls.go
@@ -19,6 +19,9 @@ var (
 	lsRecursive  bool
 	lsLongFormat bool
 	lsShowHidden bool
+	lsFilter     string
+	lsOrderBy    []string
+	lsLocalUser  string
 )
 
 // LsCmd returns the ls command
@@ -32,8 +35,10 @@ This command lists the contents of a directory on the specified Globus endpoint.
 The PATH is optional and defaults to the home directory or root of the endpoint.
 
 Examples:
-  globus transfer ls ddb59aef-6d04-11e5-ba46-22000b92c6ec
-  globus transfer ls ddb59aef-6d04-11e5-ba46-22000b92c6ec:/path/to/directory`,
+  globus ls ddb59aef-6d04-11e5-ba46-22000b92c6ec
+  globus ls ddb59aef-6d04-11e5-ba46-22000b92c6ec:/path/to/directory
+  globus ls ENDPOINT_ID:/data --filter "name:~*.txt"
+  globus ls ENDPOINT_ID:/data --orderby "name" --orderby "size DESC"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Parse endpoint ID and path
@@ -47,6 +52,9 @@ Examples:
 	cmd.Flags().BoolVarP(&lsRecursive, "recursive", "r", false, "List directories recursively")
 	cmd.Flags().BoolVarP(&lsLongFormat, "long", "l", false, "List in long format with details")
 	cmd.Flags().BoolVarP(&lsShowHidden, "all", "a", false, "Show hidden files")
+	cmd.Flags().StringVar(&lsFilter, "filter", "", "Filter results, e.g. \"name:~*.txt\" (Globus Transfer filter syntax)")
+	cmd.Flags().StringSliceVar(&lsOrderBy, "orderby", nil, "Order results, e.g. \"name\" or \"size DESC\" (repeatable)")
+	cmd.Flags().StringVar(&lsLocalUser, "local-user", "", "Local user to map to (GCSv5 mapped collections)")
 
 	return cmd
 }
@@ -80,6 +88,9 @@ func listDirectory(cmd *cobra.Command, endpointID, path string) error {
 	// Prepare listing options
 	options := &transfer.ListDirectoryOptions{
 		ShowHidden: lsShowHidden,
+		Filter:     lsFilter,
+		OrderBy:    lsOrderBy,
+		LocalUser:  lsLocalUser,
 	}
 
 	// Get the directory listing

--- a/cmd/transfer/mkdir.go
+++ b/cmd/transfer/mkdir.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	mkdirRecursive bool
+	mkdirLocalUser string
 )
 
 // MkdirCmd returns the mkdir command
@@ -43,6 +44,7 @@ Examples:
 
 	// Add flags
 	cmd.Flags().BoolVarP(&mkdirRecursive, "recursive", "p", false, "Create parent directories as needed")
+	cmd.Flags().StringVar(&mkdirLocalUser, "local-user", "", "Local user to map to (GCSv5 mapped collections)")
 
 	return cmd
 }
@@ -62,7 +64,7 @@ func createDirectory(cmd *cobra.Command, endpointID, path string) error {
 	// Create the directory. The v4 SDK takes endpoint/path/local-user
 	// positionally; the recursive flag is a client-side convenience that the
 	// operation API does not accept, so it is a no-op for now.
-	if _, err := transferClient.MakeDirectory(ctx, endpointID, path, ""); err != nil {
+	if _, err := transferClient.MakeDirectory(ctx, endpointID, path, mkdirLocalUser); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 

--- a/cmd/transfer/rename.go
+++ b/cmd/transfer/rename.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	renameLocalUser string
+)
+
 // RenameCmd returns the rename command
 func RenameCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -39,6 +43,8 @@ Examples:
 		},
 	}
 
+	cmd.Flags().StringVar(&renameLocalUser, "local-user", "", "Local user to map to (GCSv5 mapped collections)")
+
 	return cmd
 }
 
@@ -56,7 +62,7 @@ func renamePath(cmd *cobra.Command, endpointID, oldPath, newPath string) error {
 
 	// Rename the path. The v4 SDK takes endpoint/old-path/new-path/local-user
 	// positionally; local-user is optional (pass "").
-	if _, err := transferClient.Rename(ctx, endpointID, oldPath, newPath, ""); err != nil {
+	if _, err := transferClient.Rename(ctx, endpointID, oldPath, newPath, renameLocalUser); err != nil {
 		return fmt.Errorf("failed to rename: %w", err)
 	}
 

--- a/cmd/transfer/rm.go
+++ b/cmd/transfer/rm.go
@@ -15,8 +15,14 @@ import (
 )
 
 var (
-	rmRecursive bool
-	rmForce     bool
+	rmRecursive     bool
+	rmForce         bool
+	rmIgnoreMissing bool
+	rmLabel         string
+	rmDeadline      string
+	rmLocalUser     string
+	rmEnableGlobs   bool
+	rmNotify        []string
 )
 
 // RmCmd returns the rm command
@@ -49,6 +55,12 @@ Examples:
 	// Add flags
 	cmd.Flags().BoolVarP(&rmRecursive, "recursive", "r", false, "Remove directories and their contents recursively")
 	cmd.Flags().BoolVarP(&rmForce, "force", "f", false, "Force removal without confirmation")
+	cmd.Flags().BoolVar(&rmIgnoreMissing, "ignore-missing", false, "Do not error if the path does not exist")
+	cmd.Flags().StringVar(&rmLabel, "label", "", "Set a label for this task")
+	cmd.Flags().StringVar(&rmDeadline, "deadline", "", "Deadline for the task (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&rmLocalUser, "local-user", "", "Local user to map to (GCSv5 mapped collections)")
+	cmd.Flags().BoolVar(&rmEnableGlobs, "enable-globs", false, "Interpret shell-style globs in the path")
+	cmd.Flags().StringSliceVar(&rmNotify, "notify", nil, "Notification settings: any of on, off, succeeded, failed, inactive")
 
 	return cmd
 }
@@ -121,11 +133,29 @@ func removeItem(cmd *cobra.Command, endpointID, path string) error {
 		return fmt.Errorf("failed to get submission ID: %w", err)
 	}
 
+	if rmDeadline != "" {
+		if _, derr := time.Parse("2006-01-02", rmDeadline); derr != nil {
+			return fmt.Errorf("invalid deadline format, use YYYY-MM-DD: %w", derr)
+		}
+	}
+	notifySucceeded, notifyFailed, notifyInactive, nerr := parseNotify(rmNotify)
+	if nerr != nil {
+		return nerr
+	}
+
 	deleteRequest := &transfer.Delete{
-		DATA_TYPE:    "delete",
-		SubmissionID: submissionID,
-		Endpoint:     endpointID,
-		Recursive:    rmRecursive,
+		DATA_TYPE:         "delete",
+		SubmissionID:      submissionID,
+		Endpoint:          endpointID,
+		Label:             rmLabel,
+		Recursive:         rmRecursive,
+		IgnoreMissing:     rmIgnoreMissing,
+		InterpretGlob:     rmEnableGlobs,
+		LocalUser:         rmLocalUser,
+		Deadline:          rmDeadline,
+		NotifyOnSucceeded: notifySucceeded,
+		NotifyOnFailed:    notifyFailed,
+		NotifyOnInactive:  notifyInactive,
 		Items: []transfer.DeleteItem{
 			{DATA_TYPE: "delete_item", Path: path},
 		},

--- a/cmd/transfer/stat.go
+++ b/cmd/transfer/stat.go
@@ -13,6 +13,10 @@ import (
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
 )
 
+var (
+	statLocalUser string
+)
+
 // StatCmd returns the stat command
 func StatCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -38,6 +42,8 @@ Examples:
 		},
 	}
 
+	cmd.Flags().StringVar(&statLocalUser, "local-user", "", "Local user to map to (GCSv5 mapped collections)")
+
 	return cmd
 }
 
@@ -54,7 +60,7 @@ func statPath(cmd *cobra.Command, endpointID, path string) error {
 	}
 
 	// Stat the path. GenericResponse is a map[string]interface{} passthrough.
-	resp, err := transferClient.OperationStat(ctx, endpointID, path, "")
+	resp, err := transferClient.OperationStat(ctx, endpointID, path, statLocalUser)
 	if err != nil {
 		return fmt.Errorf("failed to stat path: %w", err)
 	}

--- a/cmd/transfer/task.go
+++ b/cmd/transfer/task.go
@@ -17,9 +17,13 @@ import (
 )
 
 var (
-	taskWait     bool
-	taskWaitTime int
-	taskFilter   string
+	taskWait            bool
+	taskWaitTime        int
+	taskWaitPollSeconds int
+	taskWaitHeartbeat   bool
+	taskFilter          string
+	taskFilterStatus    []string
+	taskOrderBy         []string
 )
 
 // TaskCmd returns the task command
@@ -59,7 +63,9 @@ This command lists transfer tasks with filtering options.`,
 	}
 
 	// Add flags
-	cmd.Flags().StringVar(&taskFilter, "filter", "", "Filter tasks by status (active, inactive, completed, failed)")
+	cmd.Flags().StringVar(&taskFilter, "filter", "", "Filter tasks by a single status (deprecated; use --filter-status)")
+	cmd.Flags().StringSliceVar(&taskFilterStatus, "filter-status", nil, "Filter by status: ACTIVE, INACTIVE, FAILED, SUCCEEDED (repeatable)")
+	cmd.Flags().StringSliceVar(&taskOrderBy, "orderby", nil, "Order results, e.g. \"request_time DESC\" (repeatable)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Maximum number of tasks to return")
 
 	return cmd
@@ -120,6 +126,8 @@ showing progress information while waiting.`,
 
 	// Add flags
 	cmd.Flags().IntVar(&taskWaitTime, "timeout", 300, "Maximum time to wait in seconds")
+	cmd.Flags().IntVar(&taskWaitPollSeconds, "polling-interval", 5, "Seconds between task status checks")
+	cmd.Flags().BoolVarP(&taskWaitHeartbeat, "heartbeat", "H", false, "Print a dot each polling interval while waiting")
 
 	return cmd
 }
@@ -138,11 +146,15 @@ func listTasks(cmd *cobra.Command) error {
 
 	// Prepare options for listing tasks
 	options := &transfer.ListTasksOptions{
-		Limit: limit,
+		Limit:   limit,
+		OrderBy: taskOrderBy,
 	}
 
-	// Add filters based on flags (v4 accepts a list of statuses)
-	if taskFilter != "" {
+	// Status filter: prefer the multi-valued --filter-status; fall back to the
+	// deprecated single --filter.
+	if len(taskFilterStatus) > 0 {
+		options.FilterStatus = taskFilterStatus
+	} else if taskFilter != "" {
 		options.FilterStatus = []string{taskFilter}
 	}
 
@@ -339,7 +351,11 @@ func waitForTask(cmd *cobra.Command, taskID string, timeout int) error {
 	defer s.Stop()
 
 	// Poll for task completion
-	pollInterval := 5 * time.Second
+	pollSeconds := taskWaitPollSeconds
+	if pollSeconds <= 0 {
+		pollSeconds = 5
+	}
+	pollInterval := time.Duration(pollSeconds) * time.Second
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
@@ -348,6 +364,10 @@ func waitForTask(cmd *cobra.Command, taskID string, timeout int) error {
 		case <-ctx.Done():
 			return fmt.Errorf("timeout waiting for task completion")
 		case <-ticker.C:
+			// With --heartbeat, emit a dot each polling interval.
+			if taskWaitHeartbeat {
+				fmt.Fprint(cmd.OutOrStdout(), ".")
+			}
 			// Get the task status
 			task, err := transferClient.GetTask(ctx, taskID)
 			if err != nil {

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -174,5 +174,31 @@ compute extension the Python CLI lacks.
 The only remaining item is **GCP (Globus Connect Personal)** — local-agent
 management with no SDK API, out of scope. GCS data-plane file access is started
 (`collection cat`); more data-plane operations (e.g. HTTPS directory listing)
-could follow using the same per-collection `https`-scope consent. Optional
-future polish: richer per-command flag coverage to match every Python option.
+could follow using the same per-collection `https`-scope consent.
+
+## Per-command flag parity
+
+Each command's flags were audited against the installed Python `globus` CLI and
+the gaps closed wherever the v4 SDK backs the underlying request field (flat
+transfer ops, task, endpoint + collection/gcs admin, groups, search, flows,
+timer, auth/session). Flags that the v4 SDK cannot express are intentionally
+**not** added (no silent no-ops); the notable SDK-blocked flags are:
+
+- **Auth provisioning** — `endpoint role/permission create --provision-identity`
+  (needs Auth identity provisioning, not in the Transfer SDK).
+- **`endpoint update --managed`** — requires resolving the caller's subscription
+  ID; use `--subscription-id`.
+- **`session update --all`** and `session/login --no-local-server` — no
+  "add every identity" primitive, and the login flow is paste-code only.
+- **`login --gcs/--flow/--timer`** and `session consent --timer-data-access` —
+  build dynamic dependent scopes the fixed service registry doesn't model
+  (the `project`/`collection` trees use scoped consent instead).
+- **`timer create transfer --notify/--skip-source-errors/--fail-on-quota-errors`**
+  — transfer-body extras not modeled by the timers schedule/body types.
+- **`search query --bypass-visible-to/--filter-principal-sets`** and granular
+  `task list --filter-task-id/type/label/date` — absent from the SDK options.
+- **`flows run resume --skip-inactive-reason-check`**, `flows list --limit`
+  (marker-paginated), and cosmetic `logout --yes/--ignore-errors`.
+
+These are tracked so the absence is intentional and discoverable; each becomes
+addable if/when the SDK grows the corresponding field.


### PR DESCRIPTION
## Systematic flag-parity audit (drop-in requirement)

Audited **every** command's flags against the installed Python `globus` CLI and
closed the gaps wherever the v4 SDK backs the underlying request field. Flag
names and shorthands match Python. Crucially, nothing is added as a silent
no-op — flags the v4 SDK genuinely can't express are **documented as
SDK-blocked** in `docs/PYTHON_CLI_PARITY.md` rather than faked.

### Highlights
- **transfer file ops** — `ls` (`--filter`/`--orderby`/`--local-user`),
  `transfer` (`--encrypt-data`, `--notify`, `--skip-source-errors`,
  `--fail-on-quota-errors`, `--delete-destination-extra`, checksums, local-user),
  `rm`/`delete` (`--label`/`--deadline`/`--notify`/`--ignore-missing`/
  `--enable-globs`/`--local-user`), `mkdir`/`rename`/`stat` (`--local-user`),
  `task list` (`--filter-status`, `--orderby`), `task wait`
  (`--polling-interval`, `-H/--heartbeat`).
- **endpoint / collection / gcs** — `endpoint search` filters, the full
  `endpoint update` field set, role/permission `--identity`/`--group`/
  `--all-authenticated`/`--anonymous`/notify/expiration, and the full
  `CollectionDocument` flag set on `collection create`/`update`.
- **groups/search/flows/timer/auth** — group `--parent-id`/`--request`/
  policy fields; `search query --query-document`; the flows
  administrators/starters/viewers/run-managers/monitors + subtitle/
  subscription/auth-policy/owner sets; timer `--stop-after-runs`/`--label`;
  `get-identities --provision`; `whoami --linked-identities`;
  `session update --scope`.

### Documented SDK-blocked flags
e.g. `--provision-identity`, `endpoint update --managed`, `session update --all`,
`login --gcs/--flow/--timer`, granular `task list` filters — see the new
"Per-command flag parity" section in `docs/PYTHON_CLI_PARITY.md`.

### Notes
- Built with 3 parallel audit agents over disjoint command areas (one died
  mid-run on a transient API error; its transfer/task area was finished in the
  main session).
- Verified: `GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues;
  new flags render and validate.