### PR TITLE
feat: gcp command group + endpoint local-id (match Python globus CLI)

### DIFF
--- a/cmd/gcp.go
+++ b/cmd/gcp.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/scttfrdmn/globus-go-cli/cmd/gcp"
+)
+
+// getGCPCommand returns the `gcp` command group (Globus Connect Personal
+// endpoint/collection management via the Globus service API).
+func getGCPCommand() *cobra.Command {
+	return gcp.GCPCmd()
+}

--- a/cmd/gcp/client.go
+++ b/cmd/gcp/client.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+
+// Package gcp implements the `globus gcp` command tree: management of Globus
+// Connect Personal endpoints and their collections. Matching the Python globus
+// CLI, these are CLOUD API operations (registering/updating GCP endpoints and
+// guest collections via the Transfer API) — they do not install, start, or stop
+// a local Globus Connect Personal agent. `gcp create mapped` prints a
+// setup-key used to configure an installed agent.
+package gcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/config"
+	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/transfer"
+)
+
+// getClient builds a v4 Transfer client authorized for the current profile.
+func getClient(ctx context.Context) (*transfer.Client, error) {
+	profile := viper.GetString("profile")
+
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	cfg, err := globusauth.ClientConfig(ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret, globusauth.ServiceTransfer)
+	if err != nil {
+		return nil, fmt.Errorf("not logged in: %w", err)
+	}
+
+	client, err := transfer.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transfer client: %w", err)
+	}
+	return client, nil
+}

--- a/cmd/gcp/gcp.go
+++ b/cmd/gcp/gcp.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+)
+
+// GCPCmd returns the `gcp` command group.
+func GCPCmd() *cobra.Command {
+	gcpCmd := &cobra.Command{
+		Use:   "gcp",
+		Short: "Manage Globus Connect Personal endpoints",
+		Long: `Manage Globus Connect Personal (GCP) endpoints and collections.
+
+These commands operate on the Globus service (registering and updating GCP
+endpoints and their collections); they do NOT install, start, or stop a local
+Globus Connect Personal agent. 'gcp create mapped' registers an endpoint with
+Globus and prints a setup key you use to configure an installed GCP agent.`,
+	}
+
+	gcpCmd.AddCommand(gcpCreateCmd(), gcpSetSubscriptionIDCmd())
+	return gcpCmd
+}
+
+// --- shared endpoint/collection document flags (mirrors the Python CLI) ---
+
+type gcpDocFlags struct {
+	description      string
+	organization    string
+	department       string
+	contactEmail     string
+	contactInfo      string
+	infoLink         string
+	defaultDirectory string
+	userMessage      string
+	userMessageLink  string
+	keywords         []string
+	verify           string // force|disable|default
+	public           bool
+	private          bool
+	forceEncryption  bool
+	noForceEncrypt   bool
+	subscriptionID   string
+}
+
+// registerDocFlags adds the endpoint/collection metadata flags shared by the
+// GCP create subcommands, matching the Python globus CLI.
+func registerDocFlags(cmd *cobra.Command, f *gcpDocFlags, mapped bool) {
+	cmd.Flags().StringVar(&f.description, "description", "", "Description for the collection")
+	cmd.Flags().StringVar(&f.organization, "organization", "", "Organization for the collection")
+	cmd.Flags().StringVar(&f.department, "department", "", "Department which operates the collection")
+	cmd.Flags().StringVar(&f.contactEmail, "contact-email", "", "Contact email for the collection")
+	cmd.Flags().StringVar(&f.contactInfo, "contact-info", "", "Contact info for the collection")
+	cmd.Flags().StringVar(&f.infoLink, "info-link", "", "Link for info about the collection")
+	cmd.Flags().StringVar(&f.defaultDirectory, "default-directory", "", "Default directory when browsing the collection")
+	cmd.Flags().StringVar(&f.userMessage, "user-message", "", "A message for clients to display to users")
+	cmd.Flags().StringVar(&f.userMessageLink, "user-message-link", "", "Link to additional messaging for clients to display to users")
+	cmd.Flags().StringSliceVar(&f.keywords, "keywords", nil, "Comma-separated keywords to help searches find the collection")
+	cmd.Flags().StringVar(&f.verify, "verify", "", "Set checksum verification: force, disable, or default")
+	cmd.Flags().BoolVar(&f.forceEncryption, "force-encryption", false, "Require encryption for all transfers on the collection")
+	cmd.Flags().BoolVar(&f.noForceEncrypt, "no-force-encryption", false, "Do not require encryption for transfers")
+	if mapped {
+		cmd.Flags().BoolVar(&f.public, "public", false, "Set the collection to be public")
+		cmd.Flags().BoolVar(&f.private, "private", false, "Set the collection to be private")
+		cmd.Flags().StringVar(&f.subscriptionID, "subscription-id", "", "Set the collection as managed with the given subscription ID")
+	}
+}
+
+// applyDocFlags sets the JSON keys on an endpoint document for the flags the
+// user actually provided.
+func applyDocFlags(cmd *cobra.Command, f *gcpDocFlags, doc map[string]interface{}) error {
+	set := func(name, key, val string) {
+		if cmd.Flags().Changed(name) {
+			doc[key] = val
+		}
+	}
+	set("description", "description", f.description)
+	set("organization", "organization", f.organization)
+	set("department", "department", f.department)
+	set("contact-email", "contact_email", f.contactEmail)
+	set("contact-info", "contact_info", f.contactInfo)
+	set("info-link", "info_link", f.infoLink)
+	set("default-directory", "default_directory", f.defaultDirectory)
+	set("user-message", "user_message", f.userMessage)
+	set("user-message-link", "user_message_link", f.userMessageLink)
+	if cmd.Flags().Changed("keywords") {
+		doc["keywords"] = strings.Join(f.keywords, ",")
+	}
+	switch f.verify {
+	case "":
+	case "force":
+		doc["force_verify"] = true
+		doc["disable_verify"] = false
+	case "disable":
+		doc["disable_verify"] = true
+		doc["force_verify"] = false
+	case "default":
+		doc["force_verify"] = false
+		doc["disable_verify"] = false
+	default:
+		return fmt.Errorf("invalid --verify value %q (use force, disable, or default)", f.verify)
+	}
+	if cmd.Flags().Changed("force-encryption") {
+		doc["force_encryption"] = f.forceEncryption
+	}
+	if cmd.Flags().Changed("no-force-encryption") && f.noForceEncrypt {
+		doc["force_encryption"] = false
+	}
+	if f.public {
+		doc["public"] = true
+	}
+	if f.private {
+		doc["public"] = false
+	}
+	if cmd.Flags().Changed("subscription-id") {
+		doc["subscription_id"] = f.subscriptionID
+	}
+	return nil
+}
+
+// --- gcp create (mapped | guest) ---
+
+func gcpCreateCmd() *cobra.Command {
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Globus Connect Personal collection",
+	}
+	createCmd.AddCommand(gcpCreateMappedCmd(), gcpCreateGuestCmd())
+	return createCmd
+}
+
+func gcpCreateMappedCmd() *cobra.Command {
+	var f gcpDocFlags
+	cmd := &cobra.Command{
+		Use:   "mapped DISPLAY_NAME",
+		Short: "Register a new Globus Connect Personal mapped collection (endpoint)",
+		Long: `Register a new Globus Connect Personal mapped collection with Globus.
+
+In GCP, the mapped collection and the endpoint are the same object. This does
+not install or start a local GCP agent — it performs the registration and
+prints a setup key you use to configure an installed agent.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			doc := map[string]interface{}{
+				"DATA_TYPE":         "endpoint",
+				"display_name":      args[0],
+				"is_globus_connect": true,
+			}
+			if err := applyDocFlags(cmd, &f, doc); err != nil {
+				return err
+			}
+
+			resp, err := client.CreateEndpoint(ctx, doc)
+			if err != nil {
+				return fmt.Errorf("failed to create GCP endpoint: %w", err)
+			}
+
+			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
+			if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+				return formatter.FormatOutput(resp, nil)
+			}
+			if id, ok := resp["id"].(string); ok {
+				fmt.Fprintf(cmd.OutOrStdout(), "Endpoint ID: %s\n", id)
+			}
+			if key, ok := resp["globus_connect_setup_key"].(string); ok {
+				fmt.Fprintf(cmd.OutOrStdout(), "Setup Key:   %s\n", key)
+			}
+			return nil
+		},
+	}
+	registerDocFlags(cmd, &f, true)
+	return cmd
+}
+
+func gcpCreateGuestCmd() *cobra.Command {
+	var f gcpDocFlags
+	cmd := &cobra.Command{
+		Use:   "guest DISPLAY_NAME HOST_ENDPOINT_ID:PATH",
+		Short: "Create a guest collection on a Globus Connect Personal endpoint",
+		Long: `Create a guest collection rooted at a path on a Globus Connect Personal
+host endpoint.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hostID, hostPath, ok := strings.Cut(args[1], ":")
+			if !ok || hostID == "" || hostPath == "" {
+				return fmt.Errorf("second argument must be HOST_ENDPOINT_ID:PATH")
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			doc := map[string]interface{}{
+				"DATA_TYPE":    "shared_endpoint",
+				"display_name": args[0],
+				"host_endpoint": hostID,
+				"host_path":    hostPath,
+			}
+			if err := applyDocFlags(cmd, &f, doc); err != nil {
+				return err
+			}
+
+			resp, err := client.CreateSharedEndpoint(ctx, doc)
+			if err != nil {
+				return fmt.Errorf("failed to create guest collection: %w", err)
+			}
+
+			formatter := output.NewFormatter(viper.GetString("format"), cmd.OutOrStdout())
+			if formatter.Format == output.FormatJSON || formatter.Format == output.FormatUnix {
+				return formatter.FormatOutput(resp, nil)
+			}
+			if id, ok := resp["id"].(string); ok {
+				fmt.Fprintf(cmd.OutOrStdout(), "Collection ID: %s\n", id)
+			}
+			return nil
+		},
+	}
+	registerDocFlags(cmd, &f, false)
+	return cmd
+}
+
+// --- gcp set-subscription-id ---
+
+func gcpSetSubscriptionIDCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-subscription-id ENDPOINT_ID SUBSCRIPTION_ID",
+		Short: "Set the subscription for a Globus Connect Personal endpoint",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			client, err := getClient(ctx)
+			if err != nil {
+				return err
+			}
+			if _, err := client.SetSubscriptionID(ctx, args[0], args[1]); err != nil {
+				return fmt.Errorf("failed to set subscription: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Set subscription %s on endpoint %s\n", args[1], args[0])
+			return nil
+		},
+	}
+}

--- a/cmd/parity_test.go
+++ b/cmd/parity_test.go
@@ -88,6 +88,9 @@ func TestCommandParity(t *testing.T) {
 		"collection list", "collection show", "collection create", "collection delete",
 		"gcs info", "gcs storage-gateway list", "gcs role list", "gcs role create",
 		"collection cat",
+		// Globus Connect Personal (cloud-API management) + local endpoint id.
+		"gcp create mapped", "gcp create guest", "gcp set-subscription-id",
+		"endpoint local-id",
 		// Project / client / credential management (globus-project-manager port).
 		"project list", "project create", "project admin add",
 		"project client list", "project client create",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -253,6 +253,7 @@ func addServiceCommands() {
 		getEndpointManagerCommand(),
 		getCollectionCommand(),
 		getGCSCommand(),
+		getGCPCommand(),
 		getProjectCommand(),
 		getAPICommand(),
 		getConfigCommand(),

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -80,7 +80,7 @@ func TestFlatCommandStructure(t *testing.T) {
 		"ls", "mkdir", "rm", "rename", "stat", "delete", "transfer", "task", "endpoint",
 		"bookmark", "tunnel", "stream-access-point", "endpoint-manager",
 		"group", "search", "flows", "timer", "compute", "api", "config",
-		"collection", "gcs", "project",
+		"collection", "gcs", "gcp", "project",
 		"list-commands", "version",
 	}
 	for _, name := range wantTopLevel {

--- a/cmd/transfer/endpoint.go
+++ b/cmd/transfer/endpoint.go
@@ -35,6 +35,7 @@ searching, and displaying endpoint details.`,
 		endpointPermissionCmd(),
 		endpointSetSubscriptionIDCmd(),
 		endpointMySharedEndpointListCmd(),
+		endpointLocalIDCmd(),
 	)
 
 	return endpointCmd

--- a/cmd/transfer/local_id.go
+++ b/cmd/transfer/local_id.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// endpointLocalIDCmd returns the `endpoint local-id` command, matching the
+// Python globus CLI. It reads the local Globus Connect Personal installation's
+// endpoint ID from the config directory (~/.globusonline), with no network
+// call. See globus_sdk.LocalGlobusConnectPersonal.
+func endpointLocalIDCmd() *cobra.Command {
+	// --personal is the default (and only) mode, accepted for Python parity.
+	var personal bool
+	cmd := &cobra.Command{
+		Use:   "local-id",
+		Short: "Display the local Globus Connect Personal endpoint ID",
+		Long: `Display the endpoint ID of the Globus Connect Personal installation for the
+current user, by reading the local GCP configuration directory
+(~/.globusonline). No network request is made.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := localGCPEndpointID()
+			if err != nil {
+				return err
+			}
+			if id == "" {
+				return fmt.Errorf("no Globus Connect Personal installation found for the current user")
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), id)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&personal, "personal", true, "Use the local Globus Connect Personal endpoint (default)")
+	return cmd
+}
+
+// localGCPEndpointID reads the GCP endpoint ID from the local config directory,
+// mirroring globus_sdk.LocalGlobusConnectPersonal: <config>/lta/client-id.txt
+// on non-Windows, <config>/client-id.txt on Windows, where <config> defaults to
+// ~/.globusonline. A missing file yields ("", nil).
+func localGCPEndpointID() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	configDir := filepath.Join(home, ".globusonline")
+	var idFile string
+	if runtime.GOOS == "windows" {
+		idFile = filepath.Join(configDir, "client-id.txt")
+	} else {
+		idFile = filepath.Join(configDir, "lta", "client-id.txt")
+	}
+	data, err := os.ReadFile(idFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("cannot read local endpoint ID: %w", err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -61,7 +61,7 @@ device-code flow and `identities lookup` performs a real `GetIdentities` call
 | Endpoint permissions (ACLs) | ✅ (5) | ✅ (`endpoint permission list/show/create/update/delete`) | Covered (Phase 4) |
 | Bookmarks | ✅ (5) | ✅ (`bookmark list/show/create/rename/delete`) | Covered (Phase 4) |
 | Collections / GCS management | ✅ (`collection`, `gcs`, 32 cmds) | ✅ core set — `collection list/show/create/update/delete`, `gcs info`, `gcs storage-gateway list/show`, `gcs role list/show/create/delete` | Covered (Phase 7) |
-| GCP (Connect Personal) | ✅ (6) | ❌ none | Gap (no SDK support) |
+| GCP (Connect Personal) | ✅ (6) | ✅ (`gcp create mapped/guest`, `gcp set-subscription-id`, `endpoint local-id`) | Covered — cloud-API mgmt (not local-agent control, same as Python) |
 | Streams / tunnels | ✅ (8) | ✅ (`tunnel list/show/create/update/delete/events`, `stream-access-point list/show`) | Covered (Phase 5) |
 | Search (index/query/ingest/task/role/subject) | ✅ (14) | ✅ comparable — incl. `index role list/create/delete` and `task list` | Covered |
 | Groups (member/role/policy/invite/join/leave) | ✅ (19) | ✅ — create/delete/list/show/update, member add/invite/list/remove/accept/decline/approve/reject, join/leave, `policies show/set` | Covered (Phase 4) |
@@ -127,8 +127,15 @@ Still available in the SDK but not yet wired:
   COLLECTION_ID PATH` reads a file over the collection's HTTPS data plane,
   using the collection's `https` scope (a separate per-collection data-access
   consent, escalated on first use).
-- **GCP (Globus Connect Personal)** — local-agent management; not an SDK API
-  (out of scope).
+- **GCP (Globus Connect Personal)** — DONE. Like the Python CLI, the `gcp`
+  commands manage GCP endpoints/collections through the **Globus service API**,
+  not the local agent: `gcp create mapped` registers an endpoint (via the new
+  SDK `transfer.CreateEndpoint`, SDK v4.8.1-5) and prints a setup key;
+  `gcp create guest` creates a guest collection; `gcp set-subscription-id`. The
+  one genuinely local piece, `endpoint local-id`, reads
+  `~/.globusonline/lta/client-id.txt` (no network, mirroring
+  `globus_sdk.LocalGlobusConnectPersonal`). Neither the Python CLI nor this one
+  installs/starts/stops the local GCP agent.
 
 ## Compute is a Go-only extension
 
@@ -171,10 +178,13 @@ streams/tunnels, groups, search, flows, timers, GCS `collection`/`gcs`, `api`
 raw passthrough, and the `list-commands`/`version` meta commands — plus a
 compute extension the Python CLI lacks.
 
-The only remaining item is **GCP (Globus Connect Personal)** — local-agent
-management with no SDK API, out of scope. GCS data-plane file access is started
-(`collection cat`); more data-plane operations (e.g. HTTPS directory listing)
-could follow using the same per-collection `https`-scope consent.
+The CLI now covers the full Python `globus` command surface, including GCP
+endpoint/collection management (`gcp ...`, cloud-API — matching Python, not
+local-agent control) and `endpoint local-id`. GCS data-plane file access is
+started (`collection cat`); more data-plane operations (e.g. HTTPS directory
+listing) could follow using the same per-collection `https`-scope consent.
+Installing/starting/stopping the local GCP agent is deliberately out of scope
+(the Python CLI does not do it either).
 
 ## Per-command flag parity
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
-	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-4
+	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-5
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-3 h1:LVuSPPWNZHPu4k/XcByNHeA0dJJkEy
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-3/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-4 h1:03n080wuEE63wJHyWIXgn2AEzxHS0MhouZbbf5MmoeE=
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-4/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-5 h1:pv1JbrWxTscR2+7j6/dmmGXHOiIRBVgJCF+dhkRjg6w=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-5/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=


### PR DESCRIPTION
## Globus Connect Personal support

Adds the `gcp` command group and `endpoint local-id`, matching the Python
`globus` CLI exactly. Key point: like the Python CLI, these are **Globus
service-API operations, not local-agent control** — neither CLI installs,
starts, or stops the local GCP agent.

- **`gcp create mapped DISPLAY_NAME`** — registers a GCP endpoint via the new
  SDK `transfer.CreateEndpoint` (`POST /v0.10/endpoint`, `is_globus_connect:true`)
  and prints the `globus_connect_setup_key`.
- **`gcp create guest DISPLAY_NAME HOST_ID:PATH`** — guest collection via
  `CreateSharedEndpoint`.
- **`gcp set-subscription-id`**.
- Shared endpoint/collection metadata flags on both create subcommands
  (description, organization, contact-*, keywords, verify, force-encryption,
  user-message, default-directory; mapped adds public/private/subscription-id).
- **`endpoint local-id`** — the one genuinely local piece: reads
  `~/.globusonline/lta/client-id.txt` (no network), mirroring
  `globus_sdk.LocalGlobusConnectPersonal`.

### Depends on globus-go-sdk v4.8.1-5
Adds `transfer.CreateEndpoint` (PR #58). `go.mod` bumped.

### Corrects earlier docs
The prior "GCP is out of scope / no SDK API" note was wrong — the cloud-API
surface is fully backable. Only local-agent lifecycle is out of scope (as in the
Python CLI). `PYTHON_CLI_PARITY.md` updated.

### Verification
`GOWORK=off go build/vet/test ./...` green; `golangci-lint` 0 issues; parity +
flat-structure tests assert the new commands; `endpoint local-id` reads the real
local endpoint ID.