### PR TITLE
fix: PKCE-capable SDK pin + clearer consent-failure hint (#32, partial #30)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
-	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-5
+	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-6
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-4 h1:03n080wuEE63wJHyWIXgn2AEzxHS0M
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-4/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-5 h1:pv1JbrWxTscR2+7j6/dmmGXHOiIRBVgJCF+dhkRjg6w=
 github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-5/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-6 h1:u/A3ewjly5SX6Rx2aU3IIdpJIsEs40GIxtzNJa8f+Rw=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-6/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=

--- a/pkg/globusauth/app.go
+++ b/pkg/globusauth/app.go
@@ -413,7 +413,12 @@ func ScopedClientConfigWithNamespace(ctx context.Context, profile, clientID, cli
 		}
 		// No stored token for this resource server: escalate consent.
 		if lerr := userApp.Login(ctx); lerr != nil {
-			return nil, fmt.Errorf("consent login failed: %w", lerr)
+			return nil, fmt.Errorf("consent login failed: %w\n\n"+
+				"If the browser rejected the request with \"Invalid client_id\" or "+
+				"\"PKCE code_challenge required\", the configured client cannot complete "+
+				"this consent. Set a native/public client registered for the "+
+				"https://auth.globus.org/v2/web/auth-code redirect via GLOBUS_CLIENT_ID "+
+				"or your profile config.", lerr)
 		}
 		authz, err = userApp.GetAuthorizer(ctx, resourceServer)
 		if err != nil {


### PR DESCRIPTION
Addresses **#32** and unblocks the **#30** workaround.

- **Pins the PKCE-capable SDK (v4.8.1-6).** The SDK login flow now implements
  PKCE (S256), so a `GLOBUS_CLIENT_ID` override with a proper native/public
  client can complete the `manage_projects`/`data_access` consent — previously
  it failed with "PKCE code_challenge required for client".
- **Clearer failure hint.** When consent-escalation login fails,
  `ScopedClientConfig` now explains that the configured client may be unable to
  complete the flow and how to set a valid one (`GLOBUS_CLIENT_ID` / profile
  config), rather than only "consent login failed".

**Does NOT change the default client ID.** #30's proper fix is a dedicated
registered `globus-go-cli` client (with the `.../v2/web/auth-code` redirect);
that's pending its client ID and will be a follow-up. This PR makes the override
path actually work in the meantime.