### PR TITLE
fix: ship globus-go-cli's own default client ID (closes #30)

### DIFF
--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -16,8 +16,15 @@ type ClientConfig struct {
 	ClientSecret string `json:"client_secret" yaml:"client_secret"`
 }
 
-// DefaultClientID is the default client ID for the CLI
-const DefaultClientID = "e6c75d97-532a-4c88-b031-f5a3014430e3"
+// DefaultClientID is the default (native/public) client used when the user has
+// not configured their own via profile config or GLOBUS_CLIENT_ID.
+//
+// This is globus-go-cli's own registered native/public client. It is registered
+// for the out-of-band auth-code redirect (https://auth.globus.org/v2/web/auth-code)
+// and works with the PKCE login flow. The previous default
+// (e6c75d97-…) could not complete the manage_projects consent flow — see
+// globus-go-cli issues #30 and #32.
+const DefaultClientID = "ccc07ea1-bfff-4ac0-b36e-da0141ca01c5"
 
 // LoadClientConfig loads the client configuration
 func LoadClientConfig() (*ClientConfig, error) {

--- a/pkg/globusauth/app.go
+++ b/pkg/globusauth/app.go
@@ -78,7 +78,7 @@ func SessionLogin(ctx context.Context, profile, clientID, clientSecret string, s
 
 // DefaultClientID is the native (public) client used when the user has not
 // configured their own. Matches pkg/config.DefaultClientID.
-const DefaultClientID = "e6c75d97-532a-4c88-b031-f5a3014430e3"
+const DefaultClientID = "ccc07ea1-bfff-4ac0-b36e-da0141ca01c5"
 
 // Service identifies a Globus service for scope/resource-server lookup.
 type Service string


### PR DESCRIPTION
Sets `DefaultClientID` to the project's **dedicated native/public client**
(`ccc07ea1-bfff-4ac0-b36e-da0141ca01c5`) — a Thick Client registered for the
`https://auth.globus.org/v2/web/auth-code` redirect, no secret, no pre-registered
scopes (dynamic consent).

The previous default (`e6c75d97-…`) couldn't complete the `manage_projects`
consent flow, making `project`/`collection`/`session` unusable out of the box
(#30). Combined with the PKCE login flow (#32 → SDK v4.8.1-6, already pinned),
consent escalation now works without a `GLOBUS_CLIENT_ID` override.

Closes #30. Updated in both `pkg/config` and `pkg/globusauth`.