### PR TITLE
ci: add workflow_dispatch to PR workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:  # allow manual re-runs when auto-scheduling lags
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:  # allow manual re-runs when auto-scheduling lags
   schedule:
     - cron: '0 0 * * 0' # weekly
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:  # allow manual re-runs when auto-scheduling lags
 
 jobs:
   test:


### PR DESCRIPTION
`build.yml`, `tests.yml`, and `security.yml` only triggered on push/PR. GitHub
intermittently lags scheduling PR checks on freshly-created branches (seen this
session on PRs #35 and #60, where checks never registered on the initial PR).
Adding `workflow_dispatch` lets these workflows be re-run manually
(`gh workflow run` / Actions UI) without pushing an empty commit as a nudge.
`cross-platform.yml` already had it.