### PR TITLE
test(project): cover admin ID flattening (SDK #61 follow-up)

### DIFF
--- a/cmd/project/admin.go
+++ b/cmd/project/admin.go
@@ -89,20 +89,7 @@ func listAdmins(cmd *cobra.Command, projectID string) error {
 		return fmt.Errorf("failed to get project: %w", err)
 	}
 
-	// Collect admin identity IDs from both the flat list and the expanded
-	// admins object (deduped).
-	identities := dedupeStrings(project.AdminIDs)
-	groups := append([]string(nil), project.AdminGroupIDs...)
-	if project.Admins != nil {
-		for _, id := range project.Admins.Identities {
-			identities = append(identities, id.ID)
-		}
-		for _, g := range project.Admins.Groups {
-			groups = append(groups, g.ID)
-		}
-		identities = dedupeStrings(identities)
-	}
-	groups = dedupeStrings(groups)
+	identities, groups := collectAdminIDs(project)
 
 	format := viper.GetString("format")
 	formatter := output.NewFormatter(format, cmd.OutOrStdout())
@@ -222,6 +209,26 @@ func resolveIdentityID(ctx context.Context, client *auth.Client, arg string) (st
 		return "", fmt.Errorf("no identity found for username %q", arg)
 	}
 	return identities[0].ID, nil
+}
+
+// collectAdminIDs returns a project's admin identity IDs and admin group IDs,
+// merging the flat ID lists (admin_ids/admin_group_ids) with the expanded
+// admins object (whose identities/groups are objects, not strings). Both
+// results are deduped and empty entries dropped, preserving order.
+func collectAdminIDs(project *auth.Project) (identities, groups []string) {
+	identities = dedupeStrings(project.AdminIDs)
+	groups = append([]string(nil), project.AdminGroupIDs...)
+	if project.Admins != nil {
+		for _, id := range project.Admins.Identities {
+			identities = append(identities, id.ID)
+		}
+		for _, g := range project.Admins.Groups {
+			groups = append(groups, g.ID)
+		}
+		identities = dedupeStrings(identities)
+	}
+	groups = dedupeStrings(groups)
+	return identities, groups
 }
 
 // dedupeStrings returns the input with duplicate and empty entries removed,

--- a/cmd/project/admin_test.go
+++ b/cmd/project/admin_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package project
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
+)
+
+// TestCollectAdminIDs covers the merge of the flat admin_ids/admin_group_ids
+// lists with the expanded admins object (whose identities/groups are objects,
+// not strings — SDK #61). Guards the object-field flattening that codecov
+// flagged as untested.
+func TestCollectAdminIDs(t *testing.T) {
+	tests := []struct {
+		name       string
+		project    *auth.Project
+		wantIDs    []string
+		wantGroups []string
+	}{
+		{
+			name: "flat lists only",
+			project: &auth.Project{
+				AdminIDs:      []string{"id-1", "id-2"},
+				AdminGroupIDs: []string{"grp-1"},
+			},
+			wantIDs:    []string{"id-1", "id-2"},
+			wantGroups: []string{"grp-1"},
+		},
+		{
+			name: "expanded admins object merged and deduped",
+			project: &auth.Project{
+				AdminIDs:      []string{"id-1"},
+				AdminGroupIDs: []string{"grp-1"},
+				Admins: &auth.ProjectAdmins{
+					Identities: []auth.ProjectAdminIdentity{
+						{ID: "id-1"}, // duplicate of flat list
+						{ID: "id-3"},
+					},
+					Groups: []auth.ProjectAdminGroup{
+						{ID: "grp-2", Name: "Admins"},
+					},
+				},
+			},
+			wantIDs:    []string{"id-1", "id-3"},
+			wantGroups: []string{"grp-1", "grp-2"},
+		},
+		{
+			name: "empty object entries dropped",
+			project: &auth.Project{
+				AdminIDs: []string{"id-1"},
+				Admins: &auth.ProjectAdmins{
+					Identities: []auth.ProjectAdminIdentity{{ID: ""}},
+					Groups:     []auth.ProjectAdminGroup{{ID: ""}},
+				},
+			},
+			wantIDs:    []string{"id-1"},
+			wantGroups: []string{},
+		},
+		{
+			name:       "no admins at all",
+			project:    &auth.Project{},
+			wantIDs:    []string{},
+			wantGroups: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIDs, gotGroups := collectAdminIDs(tt.project)
+			if !reflect.DeepEqual(gotIDs, tt.wantIDs) {
+				t.Errorf("identities = %v, want %v", gotIDs, tt.wantIDs)
+			}
+			if !reflect.DeepEqual(gotGroups, tt.wantGroups) {
+				t.Errorf("groups = %v, want %v", gotGroups, tt.wantGroups)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #38 (the SDK v4.8.1-7 re-pin): adds the unit test for the `project admin` ID-flattening that `codecov/patch` flagged.

- Extract the flat-list + expanded-`admins`-object merge out of `listAdmins` into a pure `collectAdminIDs(*auth.Project)` helper (no behavior change).
- `TestCollectAdminIDs`: flat-lists-only, expanded-object merge + dedupe, empty-entry drop, and no-admins cases.

Build/vet/test/golangci-lint pass (`GOWORK=off`). No release — rides the next tag.