### PR TITLE
fix: opt-in Timers login scope (#40) + satisfy project auth policies (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`login` no longer fails with `UNKNOWN_SCOPE_ERROR` out of the box (#40).**
+  The default login set no longer requests the Timers scope, whose
+  client-specific `.../timers.api` value a generic native/public client (the
+  CLI's default client included) can't request — which previously made Globus
+  reject the entire login. Timers is now opt-in: `login --scopes timers` (the
+  `--scopes` flag, previously a no-op, now selects services by name:
+  `auth,transfer,groups,search,flows,compute,timers`).
+- **`project` commands satisfy `session_required_policies` (#41).** Project
+  operations against a project protected by an authentication policy previously
+  failed with an unhandled 403. The CLI now detects the 403's
+  `authorization_parameters.session_required_policies`, re-drives the
+  `manage_projects` consent (in its isolated token namespace) with those
+  policies as `session_required_policies`, and retries the operation once —
+  mirroring the Python globus-cli. Applies to `project create/update/delete`,
+  `project client create/update/delete`, `project admin add/remove`, and
+  `project credential create/delete`. Unblocks registering a client in a
+  policy-protected project (epic #42).
+
 ## [4.8.1-6] - 2026-07-23
 
 ### Fixed

--- a/cmd/auth/device.go
+++ b/cmd/auth/device.go
@@ -66,13 +66,28 @@ func deviceLogin(cmd *cobra.Command) error {
 		clientID = globusauth.DefaultClientID
 	}
 
-	// Determine which scopes to request (default: all services).
-	scopes := loginScopes
-	if len(scopes) == 0 {
-		for _, svc := range globusauth.AllServices {
-			if s, ok := globusauth.Scope(svc); ok {
-				scopes = append(scopes, s)
+	// Determine which services to request tokens for. --scopes names services
+	// (auth,transfer,…,timers); the default set excludes Timers because its
+	// client-specific scope isn't requestable by a generic client (issue #40).
+	services := globusauth.DefaultLoginServices
+	if len(loginScopes) > 0 {
+		services = nil
+		var unknown []string
+		for _, name := range loginScopes {
+			if svc, ok := globusauth.ServiceByName(name); ok {
+				services = append(services, svc)
+			} else {
+				unknown = append(unknown, name)
 			}
+		}
+		if len(unknown) > 0 {
+			return fmt.Errorf("unknown service(s) in --scopes: %v (valid: auth,transfer,groups,search,flows,compute,timers)", unknown)
+		}
+	}
+	var scopes []string
+	for _, svc := range services {
+		if s, ok := globusauth.Scope(svc); ok {
+			scopes = append(scopes, s)
 		}
 	}
 

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -39,7 +39,7 @@ resource server so each service is authorized independently.`,
 	}
 
 	// Add login flags
-	loginCmd.Flags().StringSliceVar(&loginScopes, "scopes", []string{}, "comma-separated list of scopes to request (default: all)")
+	loginCmd.Flags().StringSliceVar(&loginScopes, "scopes", []string{}, "comma-separated services to request tokens for: auth,transfer,groups,search,flows,compute,timers (default: all except timers)")
 	loginCmd.Flags().BoolVar(&noLocalServer, "no-local-server", false, "do not start a local server for the OAuth callback")
 	loginCmd.Flags().BoolVar(&noSaveTokens, "no-save-tokens", false, "do not save tokens to disk")
 	loginCmd.Flags().BoolVar(&noOpenBrowser, "no-browser", false, "do not automatically open the browser")
@@ -70,7 +70,27 @@ func login(cmd *cobra.Command) error {
 		}
 	}
 
-	userApp, err := globusauth.NewApp(profile, clientCfg.ClientID, clientCfg.ClientSecret, globusauth.AllServices...)
+	// Resolve which services to request. Default (no --scopes) is the safe set
+	// that every scope of works with the default native client; Timers is
+	// opt-in because its client-specific scope isn't requestable by a generic
+	// client (issue #40).
+	services := globusauth.DefaultLoginServices
+	if len(loginScopes) > 0 {
+		services = nil
+		var unknown []string
+		for _, name := range loginScopes {
+			if svc, ok := globusauth.ServiceByName(name); ok {
+				services = append(services, svc)
+			} else {
+				unknown = append(unknown, name)
+			}
+		}
+		if len(unknown) > 0 {
+			return fmt.Errorf("unknown service(s) in --scopes: %v (valid: auth,transfer,groups,search,flows,compute,timers)", unknown)
+		}
+	}
+
+	userApp, err := globusauth.NewApp(profile, clientCfg.ClientID, clientCfg.ClientSecret, services...)
 	if err != nil {
 		return fmt.Errorf("failed to initialize login: %w", err)
 	}

--- a/cmd/project/admin.go
+++ b/cmd/project/admin.go
@@ -124,30 +124,29 @@ func addAdmin(cmd *cobra.Command, projectID, identityOrUsername string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
+	var identityID string
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		id, err := resolveIdentityID(ctx, client, identityOrUsername)
+		if err != nil {
+			return err
+		}
+		identityID = id
+
+		project, err := client.GetProject(ctx, projectID)
+		if err != nil {
+			return err
+		}
+
+		merged := dedupeStrings(append(project.AdminIDs, identityID))
+		update := &auth.ProjectUpdate{
+			DisplayName:  project.DisplayName,
+			ContactEmail: project.ContactEmail,
+			AdminIDs:     merged,
+		}
+		_, err = client.UpdateProject(ctx, projectID, update)
 		return err
-	}
-
-	identityID, err := resolveIdentityID(ctx, client, identityOrUsername)
-	if err != nil {
-		return err
-	}
-
-	project, err := client.GetProject(ctx, projectID)
-	if err != nil {
-		return fmt.Errorf("failed to get project: %w", err)
-	}
-
-	merged := dedupeStrings(append(project.AdminIDs, identityID))
-
-	update := &auth.ProjectUpdate{
-		DisplayName:  project.DisplayName,
-		ContactEmail: project.ContactEmail,
-		AdminIDs:     merged,
-	}
-	if _, err := client.UpdateProject(ctx, projectID, update); err != nil {
-		return fmt.Errorf("failed to update project admins: %w", err)
+	}); err != nil {
+		return fmt.Errorf("failed to add project admin: %w", err)
 	}
 
 	fmt.Printf("Added admin %s to project %s\n", identityID, projectID)
@@ -160,30 +159,28 @@ func removeAdmin(cmd *cobra.Command, projectID, identityID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
-	project, err := client.GetProject(ctx, projectID)
-	if err != nil {
-		return fmt.Errorf("failed to get project: %w", err)
-	}
-
-	reduced := make([]string, 0, len(project.AdminIDs))
-	for _, id := range project.AdminIDs {
-		if id != identityID {
-			reduced = append(reduced, id)
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		project, err := client.GetProject(ctx, projectID)
+		if err != nil {
+			return err
 		}
-	}
 
-	update := &auth.ProjectUpdate{
-		DisplayName:  project.DisplayName,
-		ContactEmail: project.ContactEmail,
-		AdminIDs:     reduced,
-	}
-	if _, err := client.UpdateProject(ctx, projectID, update); err != nil {
-		return fmt.Errorf("failed to update project admins: %w", err)
+		reduced := make([]string, 0, len(project.AdminIDs))
+		for _, id := range project.AdminIDs {
+			if id != identityID {
+				reduced = append(reduced, id)
+			}
+		}
+
+		update := &auth.ProjectUpdate{
+			DisplayName:  project.DisplayName,
+			ContactEmail: project.ContactEmail,
+			AdminIDs:     reduced,
+		}
+		_, err = client.UpdateProject(ctx, projectID, update)
+		return err
+	}); err != nil {
+		return fmt.Errorf("failed to remove project admin: %w", err)
 	}
 
 	fmt.Printf("Removed admin %s from project %s\n", identityID, projectID)

--- a/cmd/project/client.go
+++ b/cmd/project/client.go
@@ -16,12 +16,14 @@ package project
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/viper"
 
 	"github.com/scttfrdmn/globus-go-cli/pkg/config"
 	"github.com/scttfrdmn/globus-go-cli/pkg/globusauth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/core"
 	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
 )
 
@@ -60,4 +62,104 @@ func getClient(ctx context.Context) (*auth.Client, error) {
 		return nil, fmt.Errorf("failed to create auth client: %w", err)
 	}
 	return client, nil
+}
+
+// getClientWithPolicies builds a manage_projects Auth client whose token was
+// obtained under a consent that satisfies the given session_required_policies
+// (high-assurance / session freshness). It re-drives the manage_projects
+// consent in the isolated namespace with those policies, so the resulting token
+// carries them in session. Used by withProjectRetry after a 403.
+func getClientWithPolicies(ctx context.Context, policies []string) (*auth.Client, error) {
+	profile := viper.GetString("profile")
+
+	clientCfg, err := config.LoadClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	cfg, err := globusauth.ScopedSessionConsentConfig(
+		ctx, profile, clientCfg.ClientID, clientCfg.ClientSecret,
+		authResourceServer, manageProjectsScope, manageProjectsNamespace,
+		&globusauth.SessionParams{RequiredPolicies: policies},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not obtain policy-satisfying manage_projects consent: %w", err)
+	}
+
+	client, err := auth.NewClient(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth client: %w", err)
+	}
+	return client, nil
+}
+
+// withProjectRetry runs a project operation and, if it fails with a 403 that
+// carries session_required_policies (a high-assurance auth-policy requirement),
+// re-drives the manage_projects consent with those policies and retries once.
+// This mirrors the Python globus-cli, which auto-reauthenticates against the
+// returned authorization_parameters. Callers pass a closure that takes a client
+// and performs the operation; op is invoked at most twice.
+func withProjectRetry(ctx context.Context, op func(client *auth.Client) error) error {
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+	err = op(client)
+	if err == nil {
+		return nil
+	}
+	policies := sessionRequiredPolicies(err)
+	if len(policies) == 0 {
+		return err
+	}
+	fmt.Println("This project requires a high-assurance session; re-authenticating to satisfy its policy...")
+	client, cerr := getClientWithPolicies(ctx, policies)
+	if cerr != nil {
+		// Surface the original 403 alongside the re-auth failure.
+		return fmt.Errorf("%w (re-auth for required policy failed: %v)", err, cerr)
+	}
+	return op(client)
+}
+
+// sessionRequiredPolicies extracts authorization_parameters.session_required_policies
+// from a Globus API 403 error, if present. Globus returns these on the error
+// body when an auth policy demands a fresh, policy-scoped session. Returns nil
+// when the error is not such a 403.
+func sessionRequiredPolicies(err error) []string {
+	var apiErr *core.APIError
+	if !errors.As(err, &apiErr) {
+		return nil
+	}
+	if apiErr.StatusCode != 403 || apiErr.Details == nil {
+		return nil
+	}
+	ap, ok := apiErr.Details["authorization_parameters"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return toStringSlice(ap["session_required_policies"])
+}
+
+// toStringSlice coerces a decoded JSON value that may be a []interface{} of
+// strings, or a single comma-joined string, into a []string.
+func toStringSlice(v interface{}) []string {
+	switch t := v.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return t
+	case string:
+		if t == "" {
+			return nil
+		}
+		return []string{t}
+	default:
+		return nil
+	}
 }

--- a/cmd/project/client_cmd.go
+++ b/cmd/project/client_cmd.go
@@ -261,11 +261,6 @@ func pcCreate(cmd *cobra.Command) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
 	req := &auth.ClientCreate{
 		Name:         clientCreateName,
 		Project:      clientCreateProject,
@@ -279,8 +274,15 @@ func pcCreate(cmd *cobra.Command) error {
 		req.PublicClient = &public
 	}
 
-	created, err := client.CreateClient(ctx, req)
-	if err != nil {
+	var created *auth.AuthClientInfo
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		c, err := client.CreateClient(ctx, req)
+		if err != nil {
+			return err
+		}
+		created = c
+		return nil
+	}); err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
@@ -293,11 +295,6 @@ func pcUpdate(cmd *cobra.Command, clientID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
 	update := &auth.ClientUpdate{}
 	if cmd.Flags().Changed("name") {
 		update.Name = clientUpdateName
@@ -306,7 +303,10 @@ func pcUpdate(cmd *cobra.Command, clientID string) error {
 		update.Visibility = clientUpdateVisibility
 	}
 
-	if _, err := client.UpdateClient(ctx, clientID, update); err != nil {
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		_, err := client.UpdateClient(ctx, clientID, update)
+		return err
+	}); err != nil {
 		return fmt.Errorf("failed to update client: %w", err)
 	}
 
@@ -319,12 +319,9 @@ func pcDelete(cmd *cobra.Command, clientID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := client.DeleteClient(ctx, clientID); err != nil {
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		return client.DeleteClient(ctx, clientID)
+	}); err != nil {
 		return fmt.Errorf("failed to delete client: %w", err)
 	}
 
@@ -337,13 +334,11 @@ func pcUpdateRedirectURIs(cmd *cobra.Command, clientID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
 	update := &auth.ClientUpdate{RedirectURIs: clientRedirectURIs}
-	if _, err := client.UpdateClient(ctx, clientID, update); err != nil {
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		_, err := client.UpdateClient(ctx, clientID, update)
+		return err
+	}); err != nil {
 		return fmt.Errorf("failed to update redirect URIs: %w", err)
 	}
 
@@ -356,11 +351,6 @@ func pcUpdateMetadata(cmd *cobra.Command, clientID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
 	links := &auth.ClientLinksInput{}
 	if cmd.Flags().Changed("privacy-policy") {
 		links.PrivacyPolicy = clientPrivacyPolicy
@@ -370,7 +360,10 @@ func pcUpdateMetadata(cmd *cobra.Command, clientID string) error {
 	}
 
 	update := &auth.ClientUpdate{Links: links}
-	if _, err := client.UpdateClient(ctx, clientID, update); err != nil {
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		_, err := client.UpdateClient(ctx, clientID, update)
+		return err
+	}); err != nil {
 		return fmt.Errorf("failed to update client metadata: %w", err)
 	}
 

--- a/cmd/project/client_test.go
+++ b/cmd/project/client_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package project
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/core"
+)
+
+// TestSessionRequiredPolicies covers extraction of
+// authorization_parameters.session_required_policies from a Globus 403 (issue
+// #41), across the shapes the field can take on the wire.
+func TestSessionRequiredPolicies(t *testing.T) {
+	policyErr := func(sp interface{}) error {
+		return &core.APIError{
+			StatusCode: 403,
+			Details: map[string]interface{}{
+				"authorization_parameters": map[string]interface{}{
+					"session_required_policies": sp,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{
+			name: "array of strings",
+			err:  policyErr([]interface{}{"pol-1", "pol-2"}),
+			want: []string{"pol-1", "pol-2"},
+		},
+		{
+			name: "comma-joined string",
+			err:  policyErr("pol-1"),
+			want: []string{"pol-1"},
+		},
+		{
+			name: "not a 403",
+			err:  &core.APIError{StatusCode: 401, Details: map[string]interface{}{}},
+			want: nil,
+		},
+		{
+			name: "403 without authorization_parameters",
+			err:  &core.APIError{StatusCode: 403, Details: map[string]interface{}{"code": "FORBIDDEN"}},
+			want: nil,
+		},
+		{
+			name: "non-api error",
+			err:  errors.New("boom"),
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sessionRequiredPolicies(tt.err)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sessionRequiredPolicies = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSessionRequiredPoliciesWrapped verifies errors.As unwrapping finds a
+// wrapped *core.APIError carrying the policies.
+func TestSessionRequiredPoliciesWrapped(t *testing.T) {
+	inner := &core.APIError{
+		StatusCode: 403,
+		Details: map[string]interface{}{
+			"authorization_parameters": map[string]interface{}{
+				"session_required_policies": []interface{}{"pol-x"},
+			},
+		},
+	}
+	wrapped := fmtWrap(inner)
+	got := sessionRequiredPolicies(wrapped)
+	if !reflect.DeepEqual(got, []string{"pol-x"}) {
+		t.Errorf("sessionRequiredPolicies(wrapped) = %v, want [pol-x]", got)
+	}
+}
+
+// fmtWrap wraps err so it is still discoverable via errors.As.
+func fmtWrap(err error) error {
+	return &wrapErr{err}
+}
+
+type wrapErr struct{ err error }
+
+func (w *wrapErr) Error() string { return "wrapped: " + w.err.Error() }
+func (w *wrapErr) Unwrap() error { return w.err }
+
+func TestToStringSlice(t *testing.T) {
+	tests := []struct {
+		name string
+		in   interface{}
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"empty string", "", nil},
+		{"single string", "a", []string{"a"}},
+		{"string slice", []string{"a", "b"}, []string{"a", "b"}},
+		{"interface slice with empties", []interface{}{"a", "", "b"}, []string{"a", "b"}},
+		{"interface slice non-strings dropped", []interface{}{"a", 5, "b"}, []string{"a", "b"}},
+		{"unexpected type", 42, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toStringSlice(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toStringSlice(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/project/credential.go
+++ b/cmd/project/credential.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/scttfrdmn/globus-go-cli/pkg/output"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
 )
 
 // Flag variables for the credential subcommands. Prefixed with `cred` to avoid
@@ -185,13 +186,15 @@ func credCreate(cmd *cobra.Command, clientID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
-	cred, err := client.CreateClientCredential(ctx, clientID, credCreateName)
-	if err != nil {
+	var cred *auth.Credential
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		c, err := client.CreateClientCredential(ctx, clientID, credCreateName)
+		if err != nil {
+			return err
+		}
+		cred = c
+		return nil
+	}); err != nil {
 		return fmt.Errorf("failed to create credential: %w", err)
 	}
 
@@ -217,12 +220,9 @@ func credDelete(cmd *cobra.Command, clientID, credentialID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := client.DeleteClientCredential(ctx, clientID, credentialID); err != nil {
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		return client.DeleteClientCredential(ctx, clientID, credentialID)
+	}); err != nil {
 		return fmt.Errorf("failed to delete credential: %w", err)
 	}
 

--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -199,11 +199,6 @@ func createProject(cmd *cobra.Command) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
 	create := &auth.ProjectCreate{
 		DisplayName:   projectDisplayName,
 		ContactEmail:  projectContactEmail,
@@ -211,8 +206,15 @@ func createProject(cmd *cobra.Command) error {
 		AdminGroupIDs: projectAdminGroups,
 	}
 
-	project, err := client.CreateProject(ctx, create)
-	if err != nil {
+	var project *auth.Project
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		p, err := client.CreateProject(ctx, create)
+		if err != nil {
+			return err
+		}
+		project = p
+		return nil
+	}); err != nil {
 		return fmt.Errorf("failed to create project: %w", err)
 	}
 
@@ -225,11 +227,6 @@ func updateProject(cmd *cobra.Command, projectID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
 	update := &auth.ProjectUpdate{}
 	if cmd.Flags().Changed("display-name") {
 		update.DisplayName = projectDisplayName
@@ -238,7 +235,10 @@ func updateProject(cmd *cobra.Command, projectID string) error {
 		update.ContactEmail = projectContactEmail
 	}
 
-	if _, err := client.UpdateProject(ctx, projectID, update); err != nil {
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		_, err := client.UpdateProject(ctx, projectID, update)
+		return err
+	}); err != nil {
 		return fmt.Errorf("failed to update project: %w", err)
 	}
 
@@ -251,12 +251,9 @@ func deleteProject(cmd *cobra.Command, projectID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client, err := getClient(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := client.DeleteProject(ctx, projectID); err != nil {
+	if err := withProjectRetry(ctx, func(client *auth.Client) error {
+		return client.DeleteProject(ctx, projectID)
+	}); err != nil {
 		return fmt.Errorf("failed to delete project: %w", err)
 	}
 

--- a/docs/PYTHON_CLI_PARITY.md
+++ b/docs/PYTHON_CLI_PARITY.md
@@ -200,9 +200,11 @@ timer, auth/session). Flags that the v4 SDK cannot express are intentionally
   ID; use `--subscription-id`.
 - **`session update --all`** and `session/login --no-local-server` — no
   "add every identity" primitive, and the login flow is paste-code only.
-- **`login --gcs/--flow/--timer`** and `session consent --timer-data-access` —
+- **`login --gcs/--flow`** and `session consent --timer-data-access` —
   build dynamic dependent scopes the fixed service registry doesn't model
-  (the `project`/`collection` trees use scoped consent instead).
+  (the `project`/`collection` trees use scoped consent instead). Timers is now
+  selectable via `login --scopes timers` (opt-in because its client-specific
+  scope isn't requestable by a generic client — see #40).
 - **`timer create transfer --notify/--skip-source-errors/--fail-on-quota-errors`**
   — transfer-body extras not modeled by the timers schedule/body types.
 - **`search query --bypass-visible-to/--filter-principal-sets`** and granular

--- a/pkg/globusauth/app.go
+++ b/pkg/globusauth/app.go
@@ -132,10 +132,35 @@ var registry = map[Service]serviceInfo{
 	},
 }
 
-// AllServices is the set of services a full login requests scopes for.
+// AllServices is every service the CLI knows how to authorize. It is NOT the
+// default login set: ServiceTimers uses a client-specific scope
+// (.../timers.api) that a generic native/public client (including the CLI's
+// default client) is not authorized to request, so requesting it in a full
+// login makes Globus reject the whole login with UNKNOWN_SCOPE_ERROR (issue
+// #40). Use DefaultLoginServices for the out-of-box login; request Timers
+// explicitly via `login --scopes timers` when the configured client supports
+// it.
 var AllServices = []Service{
 	ServiceAuth, ServiceTransfer, ServiceGroups, ServiceSearch,
 	ServiceFlows, ServiceCompute, ServiceTimers,
+}
+
+// DefaultLoginServices is the set a plain `globus login` requests — AllServices
+// minus ServiceTimers (see AllServices for why). Every scope here is one the
+// default native client can request, so login succeeds out of the box.
+var DefaultLoginServices = []Service{
+	ServiceAuth, ServiceTransfer, ServiceGroups, ServiceSearch,
+	ServiceFlows, ServiceCompute,
+}
+
+// ServiceByName maps a service name (the registry key, e.g. "transfer",
+// "timers") to its Service. Used to resolve `login --scopes` entries.
+func ServiceByName(name string) (Service, bool) {
+	svc := Service(name)
+	if _, ok := registry[svc]; ok {
+		return svc, true
+	}
+	return "", false
 }
 
 // ResourceServer returns the resource-server identifier for a service.
@@ -191,7 +216,7 @@ func NewApp(profile, clientID, clientSecret string, services ...Service) (*app.U
 		return nil, err
 	}
 	if len(services) == 0 {
-		services = AllServices
+		services = DefaultLoginServices
 	}
 	for _, svc := range services {
 		info, ok := registry[svc]
@@ -384,6 +409,67 @@ func ScopedAppWithNamespace(profile, clientID, clientSecret, resourceServer, sco
 	}
 	userApp.AddScopeRequirements(resourceServer, scope)
 	return userApp, nil
+}
+
+// ScopedSessionConsentConfig re-drives a consent for a single (resourceServer,
+// scope) pair under a caller-chosen namespace, forcing step-up authentication
+// with the given session-enforcement parameters (e.g. session_required_policies
+// returned by a 403), then stores the resulting token in that namespace and
+// returns a *core.Config authorized with it.
+//
+// Unlike ScopedClientConfigWithNamespace (which only escalates consent when no
+// token is stored), this always runs the login flow — it is meant to be called
+// after an operation fails with a session-policy requirement, so the fresh
+// token carries the required policies in session. The token is stored in the
+// SAME namespace the scoped config reads from, so the retried operation picks
+// it up.
+func ScopedSessionConsentConfig(ctx context.Context, profile, clientID, clientSecret, resourceServer, scope, namespace string, sp *SessionParams) (*core.Config, error) {
+	if clientID == "" {
+		clientID = DefaultClientID
+	}
+
+	mgr := login.NewCommandLineLoginFlowManager(clientID, clientSecret)
+	params := login.AuthParams{
+		Scopes:         []string{scope},
+		RequestRefresh: true,
+	}
+	if sp != nil {
+		params.SessionRequiredIdentities = sp.RequiredIdentities
+		params.SessionRequiredSingleDomain = sp.RequiredSingleDomain
+		params.SessionRequiredPolicies = sp.RequiredPolicies
+		params.SessionRequiredMFA = sp.RequiredMFA
+		params.SessionMessage = sp.Message
+	}
+
+	result, err := mgr.RunLoginFlow(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("consent login failed: %w", err)
+	}
+
+	path, err := tokenStoragePath(profile)
+	if err != nil {
+		return nil, err
+	}
+	store, err := tokenstorage.NewJSONTokenStorageWithNamespace(path, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open token storage: %w", err)
+	}
+	for _, td := range result.Tokens {
+		if err := store.Store(td); err != nil {
+			return nil, fmt.Errorf("store token for %s: %w", td.ResourceServer, err)
+		}
+	}
+
+	// Build a config from the freshly stored token for the target resource server.
+	userApp, err := ScopedAppWithNamespace(profile, clientID, clientSecret, resourceServer, scope, namespace)
+	if err != nil {
+		return nil, err
+	}
+	authz, err := userApp.GetAuthorizer(ctx, resourceServer)
+	if err != nil {
+		return nil, fmt.Errorf("no token after consent for %q: %w", resourceServer, err)
+	}
+	return &core.Config{Authorizer: authz, Scopes: []string{scope}}, nil
 }
 
 // ScopedClientConfig returns a *core.Config authorized for a dynamic

--- a/pkg/globusauth/app_test.go
+++ b/pkg/globusauth/app_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package globusauth
+
+import "testing"
+
+// TestDefaultLoginServicesExcludesTimers guards issue #40: the default login
+// set must not request the Timers scope, whose client-specific scope a generic
+// native client can't request (causing UNKNOWN_SCOPE_ERROR for the whole login).
+func TestDefaultLoginServicesExcludesTimers(t *testing.T) {
+	for _, svc := range DefaultLoginServices {
+		if svc == ServiceTimers {
+			t.Fatal("DefaultLoginServices must not include ServiceTimers (issue #40)")
+		}
+	}
+	// Timers must still be a known service (opt-in via --scopes timers).
+	if _, ok := ServiceByName("timers"); !ok {
+		t.Error("ServiceTimers should remain resolvable by name for opt-in")
+	}
+	// Every default service must resolve to a real registry entry.
+	for _, svc := range DefaultLoginServices {
+		if _, ok := registry[svc]; !ok {
+			t.Errorf("DefaultLoginServices contains unknown service %q", svc)
+		}
+	}
+}
+
+func TestServiceByName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantOK  bool
+		wantSvc Service
+	}{
+		{"transfer", true, ServiceTransfer},
+		{"timers", true, ServiceTimers},
+		{"auth", true, ServiceAuth},
+		{"bogus", false, ""},
+		{"", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ServiceByName(tt.name)
+			if ok != tt.wantOK || got != tt.wantSvc {
+				t.Errorf("ServiceByName(%q) = (%q, %v), want (%q, %v)", tt.name, got, ok, tt.wantSvc, tt.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two out-of-box blockers from the public-SPA-client dogfooding (epic #42).

## #40 — `login` fails with `UNKNOWN_SCOPE_ERROR`
`globus login` requested `AllServices`, which includes the Timers scope. Timers' scope is the client-specific `.../timers.api` value, which a generic native/public client (including the CLI's default client) isn't authorized to request — so Globus rejected the **whole** login.

- Split `DefaultLoginServices` (no Timers) from `AllServices`; `login`/`device` default to the safe set.
- Wire the previously-dead `--scopes` flag to select services **by name** (`auth,transfer,groups,search,flows,compute,timers`), making Timers opt-in: `login --scopes timers`. Unknown names error clearly.

## #41 — `project` ops 403 on policy-protected projects
Project operations against a project with an authentication policy failed with an unhandled 403 carrying `authorization_parameters.session_required_policies`.

- Add `withProjectRetry`: on such a 403, re-drive the `manage_projects` consent **in its isolated token namespace** with those policies as `session_required_policies` (new `globusauth.ScopedSessionConsentConfig`), then retry once — mirroring the Python globus-cli.
- Wired through `project create/update/delete`, `project client create/update/delete`, `project admin add/remove`, `project credential create/delete`.

## Tests
`sessionRequiredPolicies`/`toStringSlice` (array, comma-string, non-403, wrapped-error shapes), `ServiceByName`, and a guard that `DefaultLoginServices` excludes Timers. Build/vet/test/golangci-lint pass (`GOWORK=off`); verified `login --help` + `--scopes bogus` at runtime.

Closes #40, closes #41. Advances #42 (only DoD verification against a live policy-protected project remains).