### PR TITLE
fix: pin SDK v4.8.1-8 (project auth-policy retry now works, SDK #63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.8.1-8] - 2026-07-23
+
+### Fixed
+- **`project` auth-policy retry now actually fires (SDK #63).** The
+  `session_required_policies` handling added in 4.8.1-7 was correct but inert at
+  runtime: the SDK's `APIError.Details` was always nil (it re-read an
+  already-drained response body), so the CLI never saw the 403's
+  `authorization_parameters` and never re-authenticated. Pinning SDK **v4.8.1-8**
+  populates `Details` from the response body, so administering a
+  policy-protected project (e.g. `project client create` — epic #42) now
+  triggers the policy-scoped re-consent and succeeds.
+
 ## [4.8.1-7] - 2026-07-23
 
 Clears the last two out-of-box blockers in the public-client registration path

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
-	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-7
+	github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-8
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-7 h1:9bD3nmRehwh5AwF42Ae/jYOPoUprSru3V59B1moO9Y0=
-github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-7/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-8 h1:sz55488j1xo8BsAMFvEBIOq/QSWHtdBxFxjAvXi8VUg=
+github.com/scttfrdmn/globus-go-sdk/v4 v4.8.1-8/go.mod h1:UrcOn5SNEZtN6z06Pllf1L63LQKsCzwer5/qIWfAfsg=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=


### PR DESCRIPTION
Pins SDK **v4.8.1-8**, which fixes `APIError.Details` being always nil (SDK #63 — response body double-read).

The `session_required_policies` retry added in 4.8.1-7 (#41) was correct but **inert**: with `Details` nil, the CLI never saw the 403's `authorization_parameters` and never re-authenticated. With this pin, administering a policy-protected project (`project client create` — epic #42) triggers the policy-scoped re-consent and succeeds end-to-end.

Build/vet/test pass (`GOWORK=off`).